### PR TITLE
Install `kind` in tools `bin` folder locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before you begin, ensure you have the following installed:
 1. **Create the Cluster**  
    Set up the Kind cluster using:
    ```sh
-   make kind
+   make kind-cluster
    ```
 
 2. **Deploy Network Components**  


### PR DESCRIPTION
# Proposed Changes

Install and use a locally installed `kind` in the `bin` folder. This will remove the dependency that we need to have `kind` being present on the host machine.