### PR TITLE
Fix network setup for non standard docker networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CMCTL_VERSION ?= latest
 .PHONY: cmctl
 cmctl: $(CMCTL) ## Download cmctl locally if necessary.
 $(CMCTL): $(LOCALBIN)
-        $(call go-install-tool,$(CMCTL),github.com/cert-manager/cmctl/v2,$(CMCTL_VERSION))
+	$(call go-install-tool,$(CMCTL),github.com/cert-manager/cmctl/v2,$(CMCTL_VERSION))
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CMCTL_VERSION ?= latest
 .PHONY: cmctl
 cmctl: $(CMCTL) ## Download cmctl locally if necessary.
 $(CMCTL): $(LOCALBIN)
-	$(call go-install-tool,$(CMCTL),github.com/cert-manager/cmctl/v2,$(CMCTL_VERSION))
+        $(call go-install-tool,$(CMCTL),github.com/cert-manager/cmctl/v2,$(CMCTL_VERSION))
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.
@@ -140,9 +140,14 @@ $(KIND): $(LOCALBIN)
 .PHONY: kubectl
 kubectl: $(KUBECTL) ## Download kubectl locally if necessary.
 $(KUBECTL): $(LOCALBIN)
-	curl --retry $(CURL_RETRIES) -fsL https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
-	ln -sf "$(KUBECTL)" "$(KUBECTL_BIN)"
-	chmod +x "$(KUBECTL_BIN)" "$(KUBECTL)"
+	@if ! $(KUBECTL) version &>/dev/null; then \
+		echo "$(KUBECTL) is not installed. Installing kubectl..."; \
+		curl --retry $(CURL_RETRIES) -fsL https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL); \
+		ln -sf "$(KUBECTL)" "$(KUBECTL_BIN)"; \
+		chmod +x "$(KUBECTL_BIN)" "$(KUBECTL)"; \
+	else \
+		echo "$(KUBECTL) is already installed."; \
+	fi
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/hack/setup-network.sh
+++ b/hack/setup-network.sh
@@ -24,7 +24,7 @@ iptables -t mangle -I PREROUTING 1 -i overlay-tun -j MARK --set-mark 1
 
 # Configure routing
 echo '100 ironcore_eth0' >> /etc/iproute2/rt_tables
-ip route add default via 172.18.0.1 dev eth0 table 100
+ip route add default via $(ip r | grep default | awk '{print $3}') dev eth0 table 100
 ip rule add fwmark 1 lookup 100
 
 # Add IPv6 route with retry mechanism


### PR DESCRIPTION
# Proposed Changes

Fixes #

- fix network setup for non standard docker networks (!=  172.18.0.1)
- download kubectl only if it doesnt exist already