### PR TITLE
Add information on podman on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ kind-cluster: kind ## Create a kind cluster
 
 setup-network: metalbond metalbond-client dpservice metalnet ## Customize the network on the kind nodes
 	$(KUBECTL) rollout status daemonset/dp-service -n dp-service-system --timeout=360s && \
-	$(KIND) get nodes | xargs -I {} sh -c 'docker cp hack/setup-network.sh {}:/setup-network.sh && docker exec {} bash -c "bash /setup-network.sh"'
+	$(KIND) get nodes | xargs -I {} sh -c '$(CRE) cp hack/setup-network.sh {}:/setup-network.sh && $(CRE) exec {} bash -c "bash /setup-network.sh"'
 
 delete: ## Delete the kind cluster
 	$(KIND) delete cluster
@@ -121,6 +121,10 @@ KUBECTL ?= $(LOCALBIN)/kubectl-$(KUBECTL_VERSION)
 KUBECTL_BIN ?= $(LOCALBIN)/kubectl
 KIND ?= $(LOCALBIN)/kind-$(KIND_VERSION)
 CMCTL ?= $(LOCALBIN)/cmctl-$(CMCTL_VERSION)
+CRE ?= $(shell if cre=$$(command -v docker); then echo $$cre; elif cre=$$(command -v podman); then echo $$cre; fi)
+ifeq ($(CRE),)
+$(error no docker or podman found, exiting...)
+endif
 
 ## Tool Versions
 KUBECTL_VERSION ?= v1.32.0

--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ $ brew install chipmk/tap/docker-mac-net-connect
 $ sudo brew services start chipmk/tap/docker-mac-net-connect
 ```
 
+### Using podman on MacOS
+
+The limitation mentioned above, for docker, still applies.
+This was tested and applies to podman 5.4 and podman machine running Fedora CoreOS 41.
+Running everything with podman requires that the podman machine runs in rootful mode; more details below.
+
+```bash
+NAME="Fedora Linux"
+VERSION="41.20250215.3.0 (CoreOS)"
+RELEASE_TYPE=stable
+ID=fedora
+VERSION_ID=41
+VERSION_CODENAME=""
+PLATFORM_ID="platform:f41"
+PRETTY_NAME="Fedora CoreOS 41.20250215.3.0"
+```
+
+```bash
+# we assume no other machines might be running, shutting down the default one
+podman machine stop
+
+# we create a new podman machine
+# 2-4GiB of memory are unfortunately not enough
+# must be rootful
+podman machine init --cpus 8 --memory 8192 --rootful ironcore-in-a-box
+podman machine start ironcore-in-a-box
+
+# change the default system connection
+podman system connection default ironcore-in-a-box-root
+
+# the dp-service requires some extra kernel modules
+podman machine ssh ironcore-in-a-box "sudo rpm-ostree install kernel-modules-extra"
+
+# this kernel modules installation requires a restart of the VM
+podman machine stop ironcore-in-a-box
+podman machine start ironcore-in-a-box
+
+# removing the sch_multiq kernel module from the blacklist
+podman machine ssh ironcore-in-a-box grep -rle \"^blacklist sch_multiq\" /etc/modprobe.d/ \| xargs -r sudo sed -i \'s/blacklist sch_multiq/#blacklist sch_multiq/\'
+```
+
 ## Installation
 
 To set up and start the IronCore stack, run the following command from the root of this repository:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ensure you have the following installed before running the project:
 * [curl](https://curl.se/)
 * [make](https://www.gnu.org/software/make/)
 * [go](https://go.dev/)
-* [docker](https://www.docker.com/)
+* [docker](https://www.docker.com/) or [podman](https://podman.io/)
 
 ### Linux Kernel Requirements
 


### PR DESCRIPTION
# Proposed Changes
On MacOS I would like to use podman instead of docker.
With this PR I am adding documentation on how this can be done.
Also modifying the Makefile so that docker or podman are automatically detected (docker preferred if both exist).