### PR TITLE
Make dpservice naming scheme consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ kind-cluster: kind ## Create a kind cluster
 	$(KIND) create cluster --image $(KIND_IMAGE) --config kind/kind-config.yaml
 
 setup-network: metalbond metalbond-client dpservice metalnet ## Customize the network on the kind nodes
-	$(KUBECTL) rollout status daemonset/dp-service -n dp-service-system --timeout=360s && \
+	$(KUBECTL) rollout status daemonset/dpservice -n dpservice-system --timeout=360s && \
 	$(KIND) get nodes | xargs -I {} sh -c '$(CRE) cp hack/setup-network.sh {}:/setup-network.sh && $(CRE) exec {} bash -c "bash /setup-network.sh"'
 
 delete: ## Delete the kind cluster

--- a/base/dpservice/dpservice-tap.yaml
+++ b/base/dpservice/dpservice-tap.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: dp-service
-  namespace: dp-service-system
+  name: dpservice
+  namespace: dpservice-system
 spec:
   template:
     spec:
       # Delete the init container from the base
       initContainers:
-      - name: init-dp-service
+      - name: init-dpservice
         $patch: delete
       containers:
       - name: prometheus-agent
         $patch: delete
-      - name: dp-service
-        # Override the command and args for dp-service:
+      - name: dpservice
+        # Override the command and args for dpservice:
         command:
         - dpservice-bin
         args:

--- a/base/dpservice/kustomization.yaml
+++ b/base/dpservice/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/ironcore-dev/dpservice/config/default?ref=v0.3.15
+  - github.com/ironcore-dev/dpservice/config/default?ref=v0.3.19
 
 images:
-  - name: dp-service
+  - name: dpservice
     newName: ghcr.io/ironcore-dev/dpservice
-    newTag: v0.3.15
+    newTag: v0.3.19
 
 patches:
-  - path: dp-service-tap.yaml
+  - path: dpservice-tap.yaml
     target:
       kind: DaemonSet
-      name: dp-service
+      name: dpservice
       namespace: system

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -18,7 +18,7 @@ podman machine start ironcore-in-a-box
 # change the default system connection
 podman system connection default ironcore-in-a-box-root
 
-# the dp-service requires some extra kernel modules
+# the dpservice requires some extra kernel modules
 podman machine ssh ironcore-in-a-box "sudo rpm-ostree install kernel-modules-extra"
 
 # this kernel modules installation requires a restart of the VM


### PR DESCRIPTION
Make dpservice related k8s resources have the consistent naming scheme. (https://github.com/ironcore-dev/dpservice/issues/728)