### PR TITLE
Add cluster name to kind config

### DIFF
--- a/kind/kind-config.yaml
+++ b/kind/kind-config.yaml
@@ -1,5 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: ironcore-in-a-box
 nodes:
 - role: control-plane
   extraMounts:


### PR DESCRIPTION
# Proposed Changes

- Set the name of the kind cluster to `ironcore-in-a-box`

This should prevent name clashes when using multiple kind clusters.
