### PR TITLE
Set kind cluster name via env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ GOOS    := $(shell go env GOOS)
 # Instead of using kindest/node:v1.32.0 we use our own image with the necessary tools installed
 KIND_IMAGE := ghcr.io/ironcore-dev/kind-node:latest
 
+# Configure the kind cluster name
+KIND_CLUSTER_NAME ?= ironcore-in-a-box
+export KIND_CLUSTER_NAME
+
 ##@ General
 
 # The help target prints out all targets with their descriptions organized

--- a/kind/kind-config.yaml
+++ b/kind/kind-config.yaml
@@ -1,6 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: ironcore-in-a-box
 nodes:
 - role: control-plane
   extraMounts:


### PR DESCRIPTION
When the name of the kind cluster is configured only in the kind-config file,
other commands in the Makefile besides `kind create cluster` will still default
to the cluster name `kind`. Therefore, this PR sets the cluster name via env
var `KIND_CLUSTER_NAME`, so that all `kind` commands use this cluster name.

A side benefit of this change is that it is now possible to dynamically set the
name via env var when running make.

# Proposed Changes

- Set `KIND_CLUSTER_NAME` in Makefile
- Remove cluster name from kind-config
