### PR TITLE
Add ceph-provider and rook-managed ceph cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ dpservice: prepare-local-config guard-cluster kubectl ## Install dpservice
 metalnet: prepare-local-config guard-cluster kubectl ## Install metalnet
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/metalnet
 
+rook: prepare-local-config guard-cluster kubectl setup-storage ## Install rook
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/rook-operator
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/rook-cluster
 
 libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster kubectl ## Install the libvirt-provider
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/libvirt-provider
@@ -146,6 +149,10 @@ remove-dpservice: guard-cluster kubectl ## Remove dpservice
 
 remove-metalnet: guard-cluster kubectl ## Remove metalnet
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/metalnet --ignore-not-found=true
+
+remove-rook: guard-cluster kubectl cleanup-storage ## Remove rook
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/rook-cluster
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/rook-operator
 
 remove-libvirt-provider: guard-cluster kubectl ## Remove libvirt-provider
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/libvirt-provider --ignore-not-found=true

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,12 @@ cleanup-storage: guard-cluster
 delete: ## Delete the kind cluster
 	$(KIND_CTX) delete cluster
 
+delete-storage: cleanup-storage delete
+
 ## Install components
 up: prepare ironcore ironcore-net apinetlet setup-network metalnetlet libvirt-provider ## Bring up the ironcore stack
+
+up-storage: up rook ceph-volume-provider
 
 prepare: prepare-local-config kubectl cmctl kind-cluster ## Prepare the environment
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/prepare
@@ -128,6 +132,8 @@ libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster 
 
 ## Remove components
 down: remove-libvirt-provider remove-metalnetlet remove-metalnet remove-dpservice remove-metalbond-client remove-metalbond remove-apinetlet remove-ironcore-net remove-ironcore unprepare ## Remove the ironcore stack
+
+down-storage: remove-ceph-volume-provider remove-rook down
 
 remove-ironcore: guard-cluster kubectl ## Remove the ironcore
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/ironcore  --ignore-not-found=true

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ rook: prepare-local-config guard-cluster kubectl setup-storage ## Install rook
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/rook-cluster
 
 ceph-volume-provider: prepare-local-config guard-cluster kubectl ## Install the ceph-volume-provider
+	# TODO: replace this hack once https://github.com/ironcore-dev/ceph-provider/issues/850 is implemented
+	@hack/detect-ceph-mon-enpoints.sh
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/ceph-volume-provider
 
 libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster kubectl ## Install the libvirt-provider

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ rook: prepare-local-config guard-cluster kubectl setup-storage ## Install rook
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/rook-operator
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/rook-cluster
 
+ceph-volume-provider: prepare-local-config guard-cluster kubectl ## Install the ceph-volume-provider
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/ceph-volume-provider
+
 libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster kubectl ## Install the libvirt-provider
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/libvirt-provider
 
@@ -153,6 +156,9 @@ remove-metalnet: guard-cluster kubectl ## Remove metalnet
 remove-rook: guard-cluster kubectl cleanup-storage ## Remove rook
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/rook-cluster
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/rook-operator
+
+remove-ceph-volume-provider: guard-cluster kubectl ## Remove the ceph-volume-provider
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/ceph-volume-provider
 
 remove-libvirt-provider: guard-cluster kubectl ## Remove libvirt-provider
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/libvirt-provider --ignore-not-found=true

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ setup-network: guard-cluster metalbond metalbond-client dpservice metalnet ## Cu
 	$(KUBECTL_CTX) rollout status daemonset/dpservice -n dpservice-system --timeout=360s && \
 	$(KIND_CTX) get nodes | xargs -I {} sh -c '$(CRE) cp hack/setup-network.sh {}:/setup-network.sh && $(CRE) exec {} bash -c "bash /setup-network.sh"'
 
+setup-storage: guard-cluster
+	$(KIND_CTX) get nodes | xargs -I {} sh -c '$(CRE) cp hack/setup-storage.sh {}:/setup-storage.sh && $(CRE) exec {} bash -c "bash /setup-storage.sh"'
+
+cleanup-storage: guard-cluster
+	$(KIND_CTX) get nodes | xargs -I {} sh -c '$(CRE) cp hack/cleanup-storage.sh {}:/cleanup-storage.sh && $(CRE) exec {} bash -c "bash /cleanup-storage.sh"'
+
 delete: ## Delete the kind cluster
 	$(KIND_CTX) delete cluster
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ This command will:
 
 During `make up`, the IPv4 public VIP range is auto-detected from the current kind container network (for example `172.19.1.0/24` when kind runs on `172.19.0.0/16`) and used to render runtime kustomize overlays under `.tmp/runtime-overlays/`.
 
+### Installing with storage
+
+By default IronCore in a Box will not deploy storage. If you need volumes in IronCore, run the following install command to deploy the IronCore stack together with ceph:
+
+```sh
+make up-storage
+```
+
+If you install IronCore in a Box with storage, it will create a loop device on the host running the kind docker container.
+This device must be detached as described in [Uninstall storage](#uninstall-storage). If the loop device is not detached, it will interfere with future installations of IronCore in a Box with storage.
+
 ### Running against a local libvirt-provider
 
 For development on `libvirt-provider` you can point IronCore in a Box at a local checkout and/or a custom image tag instead of the upstream defaults. When either of the following environment variables is set, `make up` writes a mutated copy of the kustomize tree to `.tmp/config/` and deploys from there:
@@ -128,6 +139,14 @@ To remove the kind cluster and all deployed resources, run:
 
 ```sh
 make down
+```
+
+### Uninstall storage
+
+If ceph was installed alongside IronCore, it can be uninstalled with:
+
+```sh
+make down-storage
 ```
 
 

--- a/base/ceph-volume-provider/kustomization.yaml
+++ b/base/ceph-volume-provider/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ceph-volume-provider-system
+
+resources:
+  - poollet-rbac
+  - github.com/ironcore-dev/ceph-provider/config/ceph-volume-provider/default?ref=v0.5.0
+
+images:
+  - name: volumepoollet
+    newName: ghcr.io/ironcore-dev/ironcore-volumepoollet
+    newTag: v0.5.0
+  - name: ceph-volume-provider
+    newName: ghcr.io/ironcore-dev/ceph-volume-provider
+    newTag: v0.5.0
+
+patches:
+  - path: patch-manager-deployment.yaml
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: ceph-volume-provider-system
+      $patch: delete

--- a/base/ceph-volume-provider/patch-manager-deployment.yaml
+++ b/base/ceph-volume-provider/patch-manager-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      # TODO: fix later when RBAC config is refactored in ceph-provider
+      serviceAccountName: ceph-volume-provider-controller-manager
+      containers:
+        - name: manager
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+        - name: ceph-volume-provider
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /var/cfg/classes
+              name: supported-volume-classes
+            - mountPath: /var/cfg/ceph/
+              name: ceph-keyring
+            - mountPath: /var/cfg/kek
+              name: ceph-kek
+      volumes:
+        - name: supported-volume-classes
+          configMap:
+            name: supported-volume-classes
+        - name: ceph-keyring
+          secret:
+            secretName: rook-ceph-admin-keyring
+        - name: ceph-kek
+          secret:
+            secretName: ceph-kek

--- a/base/ceph-volume-provider/poollet-rbac/kustomization.yaml
+++ b/base/ceph-volume-provider/poollet-rbac/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: ceph-volume-provider-
+
+resources:
+  # TODO: remove once RBAC in ceph provider is cleaned up
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
+  - github.com/ironcore-dev/ironcore/config/volumepoollet-broker/poollet-rbac?ref=v0.5.0

--- a/base/ceph-volume-provider/poollet-rbac/leader_election_role.yaml
+++ b/base/ceph-volume-provider/poollet-rbac/leader_election_role.yaml
@@ -1,0 +1,37 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/base/ceph-volume-provider/poollet-rbac/leader_election_role_binding.yaml
+++ b/base/ceph-volume-provider/poollet-rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/base/rook-cluster/cluster.yaml
+++ b/base/rook-cluster/cluster.yaml
@@ -49,14 +49,3 @@ spec:
       bdev_flock_retry: "20"
       bluefs_buffered_io: "false"
       mon_data_avail_warn: "10"
----
-apiVersion: ceph.rook.io/v1
-kind: CephBlockPool
-metadata:
-  name: builtin-mgr
-  namespace: rook-ceph # namespace:cluster
-spec:
-  name: .mgr
-  replicated:
-    size: 1
-    requireSafeReplicaSize: false

--- a/base/rook-cluster/cluster.yaml
+++ b/base/rook-cluster/cluster.yaml
@@ -1,0 +1,62 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph # namespace:cluster
+spec:
+  dataDirHostPath: /var/lib/rook
+  cephVersion:
+    image: quay.io/ceph/ceph:v19.2.3
+    allowUnsupported: true
+  mon:
+    count: 1
+    allowMultiplePerNode: true
+  # test environments can skip ok-to-stop checks during upgrades
+  skipUpgradeChecks: true
+  mgr:
+    count: 1
+    allowMultiplePerNode: true
+    modules:
+      - name: rook
+        enabled: true
+  dashboard:
+    enabled: true
+  crashCollector:
+    disable: true
+  storage:
+    useAllNodes: true
+    useAllDevices: false
+    allowDeviceClassUpdate: true
+    allowOsdCrushWeightUpdate: false
+    devices:
+      - name: /dev/loop0
+  monitoring:
+    enabled: false
+  healthCheck:
+    daemonHealth:
+      mon:
+        interval: 45s
+        timeout: 600s
+  priorityClassNames:
+    all: system-node-critical
+    mgr: system-cluster-critical
+  disruptionManagement:
+    managePodBudgets: true
+  cephConfig:
+    global:
+      osd_pool_default_size: "1"
+      mon_warn_on_pool_no_redundancy: "false"
+      bdev_flock_retry: "20"
+      bluefs_buffered_io: "false"
+      mon_data_avail_warn: "10"
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: builtin-mgr
+  namespace: rook-ceph # namespace:cluster
+spec:
+  name: .mgr
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false

--- a/base/rook-cluster/kustomization.yaml
+++ b/base/rook-cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster.yaml
+  - pool-builtin-mgr.yaml
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/headless-mon-service.yaml
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/toolbox.yaml

--- a/base/rook-cluster/pool-builtin-mgr.yaml
+++ b/base/rook-cluster/pool-builtin-mgr.yaml
@@ -1,0 +1,10 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: builtin-mgr
+spec:
+  # Ceph requires the name of the pool to be .mgr
+  name: .mgr
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false

--- a/base/rook-operator/configmap-patch.yaml
+++ b/base/rook-operator/configmap-patch.yaml
@@ -1,0 +1,11 @@
+# Patch to modify correct setup for gardenshed
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rook-ceph-operator-config
+  namespace: rook-ceph
+data:
+  ROOK_CEPH_ALLOW_LOOP_DEVICES: "true"
+
+  ROOK_CSI_DISABLE_DRIVER: "true"
+  ROOK_USE_CSI_OPERATOR: "false"

--- a/base/rook-operator/deployment-patch.yaml
+++ b/base/rook-operator/deployment-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  template:
+    spec:
+      containers:
+        - name: rook-ceph-operator
+          resources:
+           limits:
+             cpu: 500m
+             memory: 512Mi
+           requests:
+             cpu: 100m
+             memory: 128Mi

--- a/base/rook-operator/kustomization.yaml
+++ b/base/rook-operator/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/monitoring/rbac.yaml
+  - https://raw.githubusercontent.com/rook/rook/v1.18.9/deploy/examples/operator.yaml
+
+patches:
+  - path: configmap-patch.yaml
+  - path: deployment-patch.yaml

--- a/base/volume-classes/general-purpose.yaml
+++ b/base/volume-classes/general-purpose.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: VolumeClass
+metadata:
+  name: general-purpose
+  labels:
+    environment: production
+capabilities:
+  iops: 16000
+  tps: 250Mi
+resizePolicy: ExpandOnly

--- a/base/volume-classes/kustomization.yaml
+++ b/base/volume-classes/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - general-purpose.yaml

--- a/cluster/local/ceph-volume-provider/ceph-block-pool.yaml
+++ b/cluster/local/ceph-volume-provider/ceph-block-pool.yaml
@@ -1,0 +1,9 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: ceph-volume-provider
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false

--- a/cluster/local/ceph-volume-provider/ceph-client.yaml
+++ b/cluster/local/ceph-volume-provider/ceph-client.yaml
@@ -1,0 +1,10 @@
+apiVersion: ceph.rook.io/v1
+kind: CephClient
+metadata:
+  name: ceph-volume-provider
+  namespace: rook-ceph
+spec:
+  caps:
+    mgr: profile rbd pool=ceph-volume-provider
+    mon: profile rbd
+    osd: profile rbd pool=ceph-volume-provider

--- a/cluster/local/ceph-volume-provider/ceph-kek.yaml
+++ b/cluster/local/ceph-volume-provider/ceph-kek.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  passphrase: aXJvbmNvcmUtaW4tYS1ib3gtcGFzc3BocmFzZTEyMzQ=
+kind: Secret
+metadata:
+  name: ceph-kek
+  namespace: rook-ceph
+type: Opaque

--- a/cluster/local/ceph-volume-provider/classes-configmap.yaml
+++ b/cluster/local/ceph-volume-provider/classes-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: supported-volume-classes
+  namespace: ceph-volume-provider-system
+data:
+  supported-volume-classes.json: |-
+    [
+      {
+        "name": "general-purpose",
+        "capabilities": {
+          "tps": 262144000,
+          "iops": 16000
+        }
+      }
+    ]

--- a/cluster/local/ceph-volume-provider/kustomization.yaml
+++ b/cluster/local/ceph-volume-provider/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: rook-ceph
+
+resources:
+  - ../../../base/ceph-volume-provider
+  - ../../../base/volume-classes
+  - classes-configmap.yaml
+  - ceph-block-pool.yaml
+  - ceph-client.yaml
+  - ceph-kek.yaml
+
+patches:
+  - path: patch-manager-deployment.yaml

--- a/cluster/local/ceph-volume-provider/patch-manager-deployment.yaml
+++ b/cluster/local/ceph-volume-provider/patch-manager-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: ceph-volume-provider-system
+  name: ceph-volume-provider-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+            - --volume-pool-name=ironcore-in-a-box
+            - --provider-id=ceph-provider://ironcore-in-a-box
+            - --volume-runtime-endpoint=unix:/var/run/iri-volume.sock
+            - --controllers=*
+            # - --rotate-certificates
+        - name: ceph-volume-provider
+          args:
+            - --address=/var/run/iri-volume.sock
+            - --ceph-keyring-file=/var/cfg/ceph/keyring
+            - --supported-volume-classes=/var/cfg/classes/supported-volume-classes.json
+            - --zap-log-level=2
+            - --ceph-user=admin
+            - --ceph-pool=ceph-volume-provider
+            - --ceph-client=client.ceph-volume-provider
+            # TODO: How to set the IP address of the monitor? headless service is not resolvable from libvirt
+            - --ceph-monitors=10.96.11.187:6789
+            - --ceph-kek-path=/var/cfg/kek/passphrase
+            - --limits-burst-duration=60
+            - --limits-burst-factor=20

--- a/cluster/local/ceph-volume-provider/patch-manager-deployment.yaml
+++ b/cluster/local/ceph-volume-provider/patch-manager-deployment.yaml
@@ -26,8 +26,7 @@ spec:
             - --ceph-user=admin
             - --ceph-pool=ceph-volume-provider
             - --ceph-client=client.ceph-volume-provider
-            # TODO: How to set the IP address of the monitor? headless service is not resolvable from libvirt
-            - --ceph-monitors=10.96.11.187:6789
+            - --ceph-monitors=CHANGED_BY_hack/detect-ceph-mon-endpoints.sh
             - --ceph-kek-path=/var/cfg/kek/passphrase
             - --limits-burst-duration=60
             - --limits-burst-factor=20

--- a/cluster/local/rook-cluster/kustomization.yaml
+++ b/cluster/local/rook-cluster/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/rook-cluster

--- a/cluster/local/rook-operator/kustomization.yaml
+++ b/cluster/local/rook-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/rook-operator

--- a/examples/machine/machine-volume.yaml
+++ b/examples/machine/machine-volume.yaml
@@ -1,0 +1,64 @@
+apiVersion: compute.ironcore.dev/v1alpha1
+kind: Machine
+metadata:
+  name: webapp-vol
+spec:
+  volumes:
+    - name: rootdisk
+      ephemeral:
+        volumeTemplate:
+          spec:
+            dataSource:
+              osImage:
+                architecture: arm64 # amd64
+                image: ghcr.io/ironcore-dev/gardenlinux/gardener:2150.0.0-kvm
+            resources:
+              storage: 3Gi
+            volumeClassRef:
+              name: general-purpose
+  networkInterfaces:
+    - name: default
+      networkInterfaceRef:
+        name: webapp-vol
+  machineClassRef:
+    name: t3-small
+  ignitionRef:
+    name: ignition-vol
+---
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: Network
+metadata:
+  name: webapp-vol
+---
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: VirtualIP
+metadata:
+  name: webapp-vol
+spec:
+  ipFamily: IPv4
+  type: Public
+---
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: NetworkInterface
+metadata:
+  labels:
+    foo: bar
+  name: webapp-vol
+spec:
+  networkRef:
+    name: webapp-vol
+  ipFamilies:
+    - IPv4
+  ips:
+    - value: 10.0.0.1 # internal IP
+  virtualIP:
+    virtualIPRef:
+      name: webapp-vol
+---
+apiVersion: v1
+data:
+  ignition.yaml: eyJpZ25pdGlvbiI6eyJ2ZXJzaW9uIjoiMy4zLjAifSwicGFzc3dkIjp7InVzZXJzIjpbeyJncm91cHMiOlsid2hlZWwiXSwiaG9tZURpciI6Ii9ob21lL2lyb25jb3JlIiwibmFtZSI6Imlyb25jb3JlIiwicGFzc3dvcmRIYXNoIjoiJDYkR0VndzRBT09NNTdXSU9sUSRHZ1p5MVg3N3Rwbi8xZTE1NmRlRldIMVVQd29wbWQ2dTZHaWlHNTFob21lbjJ6aGNWQ0Fhai9OUXYvbDF4MVJwSVIxUHZ5TWhYQzdzMG5iZTNLbXE0MCIsInNoZWxsIjoiL2Jpbi9iYXNoIn1dfSwic3RvcmFnZSI6eyJkaXJlY3RvcmllcyI6W3siZ3JvdXAiOnsibmFtZSI6Imlyb25jb3JlIn0sInBhdGgiOiIvaG9tZS9pcm9uY29yZS8uc3NoIiwidXNlciI6eyJuYW1lIjoiaXJvbmNvcmUifSwibW9kZSI6NDQ4fV0sImZpbGVzIjpbeyJwYXRoIjoiL2V0Yy9zeXN0ZW1kL3Jlc29sdmVkLmNvbmYuZC9kbnMuY29uZiIsImNvbnRlbnRzIjp7ImNvbXByZXNzaW9uIjoiIiwic291cmNlIjoiZGF0YTosJTVCUmVzb2x2ZSU1RCUwQUROUyUzRDguOC44LjglMEEifSwibW9kZSI6NDIwfV19LCJzeXN0ZW1kIjp7InVuaXRzIjpbeyJjb250ZW50cyI6IltVbml0XVxuRGVzY3JpcHRpb249RW5hYmxlIGVhc3kgcGFzc3dvcmQgbG9naW5cblxuW1NlcnZpY2VdXG5UaW1lb3V0U3RhcnRTZWM9MFxuRXhlY1N0YXJ0PS9iaW4vYmFzaCAtYyBcInNlZCAtaSAtZSAncy9eXFxzKkF1dGhlbnRpY2F0aW9uTWV0aG9kc1xcc1xcKy4qJC8jIFx1MDAyNi8nIC1lICcvXlxccypQYXNzd29yZEF1dGhlbnRpY2F0aW9uXFxzXFwrL2QnIC1lICckYVBhc3N3b3JkQXV0aGVudGljYXRpb24geWVzJyAvZXRjL3NzaC9zc2hkX2NvbmZpZ1wiXG5cbltJbnN0YWxsXVxuV2FudGVkQnk9bXVsdGktdXNlci50YXJnZXRcbiIsImVuYWJsZWQiOnRydWUsIm5hbWUiOiJwYXNzd2Quc2VydmljZSJ9LHsiZW5hYmxlZCI6dHJ1ZSwibmFtZSI6InNzaC5zZXJ2aWNlIn1dfX0K
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: ignition-vol

--- a/hack/cleanup-storage.sh
+++ b/hack/cleanup-storage.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Delete storage disks..."
+if losetup /dev/loop0 > /dev/null 2>&1; then
+    losetup -d /dev/loop0
+fi
+
+if [ -f /var/tmp/osd-disk0 ]; then
+    rm /var/tmp/osd-disk0
+fi

--- a/hack/detect-ceph-mon-enpoints.sh
+++ b/hack/detect-ceph-mon-enpoints.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_FILE="$SCRIPT_DIR/../.tmp/config/cluster/local/ceph-volume-provider/patch-manager-deployment.yaml"
+
+RETRY_INTERVAL=${RETRY_INTERVAL:-5}
+MAX_RETRIES=${MAX_RETRIES:-20}
+
+# Retry until the rook-ceph-mon-endpoints configmap exists and contains at least
+# one endpoint. The configmap will only be created and populated during the rook
+# cluster creation.
+monitors=""
+for ((i = 1; i <= MAX_RETRIES; i++)); do
+  raw=$(kubectl -n rook-ceph get configmap rook-ceph-mon-endpoints -o jsonpath='{.data.data}' 2>/dev/null || true)
+
+  if [[ -n "$raw" ]]; then
+    parsed=$(echo "$raw" | tr ',' '\n' | sed 's/^[^=]*=//' | tr '\n' ',' | sed 's/,$//')
+    if [[ -n "$parsed" ]]; then
+      monitors="$parsed"
+      break
+    fi
+  fi
+
+  echo "Waiting for ceph mon endpoints (attempt $i/$MAX_RETRIES)..."
+  sleep "$RETRY_INTERVAL"
+done
+
+if [[ -z "$monitors" ]]; then
+  echo "Error: timed out waiting for ceph mon endpoints" >&2
+  exit 1
+fi
+
+echo "Detected ceph monitors: $monitors"
+
+# Replace the --ceph-monitors= value in the patch file
+sed "s|--ceph-monitors=.*|--ceph-monitors=$monitors|" "$PATCH_FILE" > "$PATCH_FILE.tmp" && mv "$PATCH_FILE.tmp" "$PATCH_FILE"
+
+echo "Updated $PATCH_FILE"

--- a/hack/setup-storage.sh
+++ b/hack/setup-storage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "Prepare storage disks..."
+# OSD disk must have a minimum size of 5GB
+if [ ! -f /var/tmp/osd-disk0 ]; then
+    dd if=/dev/zero of=/var/tmp/osd-disk0 bs=1M count=5120
+fi
+
+if ! losetup /dev/loop0 > /dev/null 2>&1; then
+    losetup /dev/loop0 /var/tmp/osd-disk0
+fi


### PR DESCRIPTION
# Proposed Changes

Deploy `volumepoollet` and `ceph-provider` to the ironcore-in-a-box setup. This
PR uses rook to install a test ceph cluster with a single OSD (on a loop
device) on the kind node.

Fixes #34 
