### PR TITLE
Add public VIP detection and rendering for kustomize overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .vscode/*
 bin/
 dev/
-
+.tmp/

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ guard-cluster: ## Verify the target kind cluster exists and kubectl context is c
 		exit 1; \
 	fi
 
+.PHONY: render-public-vip-overlays
+render-public-vip-overlays: guard-cluster ## Render runtime kustomize overlays from detected public VIP config
+	@hack/render-public-vip-overlays.sh "$(CRE)" "$(KIND_CLUSTER_NAME)" "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)"
+
 kind-cluster: kind ## Create a kind cluster
 	$(KIND_CTX) create cluster --image $(KIND_IMAGE) --config kind/kind-config.yaml
 
@@ -73,8 +77,8 @@ prepare: kubectl cmctl kind-cluster ## Prepare the environment
 ironcore: prepare kubectl ## Install the ironcore
 	$(KUBECTL_CTX) apply -k cluster/local/ironcore
 
-ironcore-net: guard-cluster kubectl ## Install the ironcore-net
-	$(KUBECTL_CTX) apply -k cluster/local/ironcore-net
+ironcore-net: render-public-vip-overlays guard-cluster kubectl ## Install the ironcore-net
+	$(KUBECTL_CTX) apply -k "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net"
 
 apinetlet: guard-cluster kubectl ## Install the apinetlet
 	$(KUBECTL_CTX) apply -k cluster/local/apinetlet
@@ -85,8 +89,8 @@ metalnetlet: guard-cluster kubectl ## Install the metalnetlet
 metalbond: guard-cluster kubectl ## Install metalbond
 	$(KUBECTL_CTX) apply -k cluster/local/metalbond
 
-metalbond-client: guard-cluster kubectl ## Install metalbond-client
-	$(KUBECTL_CTX) apply -k cluster/local/metalbond-client
+metalbond-client: render-public-vip-overlays guard-cluster kubectl ## Install metalbond-client
+	$(KUBECTL_CTX) apply -k "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client"
 
 dpservice: guard-cluster kubectl ## Install dpservice
 	$(KUBECTL_CTX) apply -k cluster/local/dpservice
@@ -137,6 +141,7 @@ unprepare: guard-cluster kubectl ## Unprepare the environment
 LOCALDIR ?= $(shell pwd)
 LOCALBIN ?= $(LOCALDIR)/bin
 LOCALBATS ?= $(LOCALDIR)/.bats
+PUBLIC_VIP_RUNTIME_OVERLAYS_DIR ?= $(LOCALDIR)/.tmp/runtime-overlays
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ironcore: prepare kubectl ## Install the ironcore
 	$(KUBECTL_CTX) apply -k cluster/local/ironcore
 
 ironcore-net: render-public-vip-overlays guard-cluster kubectl ## Install the ironcore-net
-	$(KUBECTL_CTX) apply -k "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net"
+	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net",cluster/local/ironcore-net)
 
 apinetlet: guard-cluster kubectl ## Install the apinetlet
 	$(KUBECTL_CTX) apply -k cluster/local/apinetlet
@@ -90,7 +90,7 @@ metalbond: guard-cluster kubectl ## Install metalbond
 	$(KUBECTL_CTX) apply -k cluster/local/metalbond
 
 metalbond-client: render-public-vip-overlays guard-cluster kubectl ## Install metalbond-client
-	$(KUBECTL_CTX) apply -k "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client"
+	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client",cluster/local/metalbond-client)
 
 dpservice: guard-cluster kubectl ## Install dpservice
 	$(KUBECTL_CTX) apply -k cluster/local/dpservice
@@ -197,7 +197,7 @@ check-submodules:
 
 .PHONY: test
 test: check-submodules $(KIND) $(KUBECTL)
-	@export PATH=$(LOCALBIN):$(PATH); \
+	@export "PATH=$(LOCALBIN):$(PATH)"; \
 	export BATS_SOURCES=$(LOCALBATS); \
 	export EXAMPLES=$(LOCALDIR)/examples; \
 	export KUBECTL_CTX="$(KUBECTL_CTX)"; \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This command will:
 1.  Create a local kind cluster (if it doesn't exist).
 2.  Deploy the IronCore stack components into the cluster.
 
+During `make up`, the IPv4 public VIP range is auto-detected from the current kind container network (for example `172.19.1.0/24` when kind runs on `172.19.0.0/16`) and used to render runtime kustomize overlays under `.tmp/runtime-overlays/`.
+
 ## Examples
 
 You can find examples of how to use the IronCore API in the [Examples](examples/) directory. You can spin up a VM in a [VPC / Overlay Network](https://en.wikipedia.org/wiki/Virtual_private_cloud) with a virtual IP. Using the command `kubectl get machine,network,nic,virtualip` to find out status and more information regarding the provisioned VM. By default, VMs enable password login for easy accessing and testing. The default username and password are `ironcore` and `best123`. Customized ignition can be also generated and used for other purposes.

--- a/hack/detect-public-vip-config.sh
+++ b/hack/detect-public-vip-config.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 <container-runtime-binary> [kind-cluster-name]" >&2
+    exit 1
+fi
+
+runtime_bin=$1; shift
+kind_cluster_name=${1:-ironcore-in-a-box}
+kind_control_plane="${kind_cluster_name}-control-plane"
+
+network_name=$("$runtime_bin" inspect "$kind_control_plane" \
+    --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' 2>/dev/null | head -n1 || true)
+
+if [ -z "$network_name" ]; then
+    fail "failed to detect container network for $kind_control_plane"
+fi
+
+subnet_ipv4=""
+subnet_ipv4=$("$runtime_bin" network inspect "$network_name" \
+    --format '{{range .IPAM.Config}}{{println .Subnet}}{{end}}' 2>/dev/null \
+    | awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+$/ { print; exit }' || true)
+
+if [ -z "$subnet_ipv4" ]; then
+    fail "failed to detect IPv4 subnet for network '$network_name'"
+fi
+
+network=${subnet_ipv4%/*}
+prefix_len=${subnet_ipv4#*/}
+IFS='.' read -r o1 o2 o3 _ <<<"$network"
+
+if [ -z "${o1:-}" ] || [ -z "${o2:-}" ] || [ -z "${o3:-}" ] || ! [[ "$prefix_len" =~ ^[0-9]+$ ]]; then
+    fail "invalid subnet format: $subnet_ipv4"
+fi
+
+if [ "$prefix_len" -le 16 ]; then
+    vip_base="$o1.$o2.1"
+elif [ "$prefix_len" -le 24 ]; then
+    vip_base="$o1.$o2.$o3"
+else
+    fail "unsupported subnet prefix length '$prefix_len' for '$subnet_ipv4'"
+fi
+
+cat <<EOF
+PUBLIC_PREFIX_IPV4=${vip_base}.1/24
+PUBLIC_CIDR_IPV4=${vip_base}.0/24
+PUBLIC_VIP_IPV4=${vip_base}.1
+EOF

--- a/hack/detect-public-vip-config.sh
+++ b/hack/detect-public-vip-config.sh
@@ -19,8 +19,13 @@ runtime_bin=$1; shift
 kind_cluster_name=${1:-ironcore-in-a-box}
 kind_control_plane="${kind_cluster_name}-control-plane"
 
-network_name=$("$runtime_bin" inspect "$kind_control_plane" \
-    --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' 2>/dev/null | head -n1 || true)
+network_names=$("$runtime_bin" inspect "$kind_control_plane" \
+    --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' 2>/dev/null || true)
+
+network_name=$(printf '%s\n' "$network_names" | awk '$0 == "kind" { print; exit }')
+if [ -z "$network_name" ]; then
+    network_name=$(printf '%s\n' "$network_names" | awk 'NF { print; exit }')
+fi
 
 if [ -z "$network_name" ]; then
     fail "failed to detect container network for $kind_control_plane"

--- a/hack/detect-public-vip-config.sh
+++ b/hack/detect-public-vip-config.sh
@@ -16,28 +16,15 @@ if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
 fi
 
 runtime_bin=$1; shift
-kind_cluster_name=${1:-ironcore-in-a-box}
-kind_control_plane="${kind_cluster_name}-control-plane"
+# kind-cluster-name is accepted for interface compatibility but unused;
+# kind always creates its Docker/Podman network as "kind".
 
-network_names=$("$runtime_bin" inspect "$kind_control_plane" \
-    --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' 2>/dev/null || true)
-
-network_name=$(printf '%s\n' "$network_names" | awk '$0 == "kind" { print; exit }')
-if [ -z "$network_name" ]; then
-    network_name=$(printf '%s\n' "$network_names" | awk 'NF { print; exit }')
-fi
-
-if [ -z "$network_name" ]; then
-    fail "failed to detect container network for $kind_control_plane"
-fi
-
-subnet_ipv4=""
-subnet_ipv4=$("$runtime_bin" network inspect "$network_name" \
+subnet_ipv4=$("$runtime_bin" network inspect kind \
     --format '{{range .IPAM.Config}}{{println .Subnet}}{{end}}' 2>/dev/null \
     | awk '/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+$/ { print; exit }' || true)
 
 if [ -z "$subnet_ipv4" ]; then
-    fail "failed to detect IPv4 subnet for network '$network_name'"
+    fail "failed to detect IPv4 subnet for 'kind' network"
 fi
 
 network=${subnet_ipv4%/*}

--- a/hack/render-public-vip-overlays.sh
+++ b/hack/render-public-vip-overlays.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <container-runtime-binary> <kind-cluster-name> <runtime-overlays-dir>" >&2
+    exit 1
+fi
+
+runtime_bin=$1; shift
+kind_cluster_name=$1; shift
+runtime_overlays_dir=$1; shift
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+public_vip_config=$("$repo_root/hack/detect-public-vip-config.sh" "$runtime_bin" "$kind_cluster_name")
+public_prefix_ipv4=$(awk -F= '$1 == "PUBLIC_PREFIX_IPV4" {print $2}' <<<"$public_vip_config")
+public_cidr_ipv4=$(awk -F= '$1 == "PUBLIC_CIDR_IPV4" {print $2}' <<<"$public_vip_config")
+
+if [ -z "$public_prefix_ipv4" ] || [ -z "$public_cidr_ipv4" ]; then
+    echo "failed to detect PUBLIC_PREFIX_IPV4/PUBLIC_CIDR_IPV4" >&2
+    exit 1
+fi
+
+echo "Detected public VIP configuration:"
+echo "$public_vip_config"
+
+ironcore_net_overlay="$runtime_overlays_dir/ironcore-net"
+metalbond_client_overlay="$runtime_overlays_dir/metalbond-client"
+mkdir -p "$ironcore_net_overlay" "$metalbond_client_overlay"
+
+ironcore_net_base=$(realpath --relative-to "$ironcore_net_overlay" "$repo_root/cluster/local/ironcore-net")
+metalbond_client_base=$(realpath --relative-to "$metalbond_client_overlay" "$repo_root/cluster/local/metalbond-client")
+
+cat > "$ironcore_net_overlay/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - $ironcore_net_base
+
+patches:
+  - path: public-prefix-patch.yaml
+EOF
+
+sed -E "s#--public-prefix=[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+#--public-prefix=$public_prefix_ipv4#g" \
+    "$repo_root/base/ironcore-net/patch-apiserver-deployment.yaml" \
+    > "$ironcore_net_overlay/public-prefix-patch.yaml"
+
+cat > "$metalbond_client_overlay/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - $metalbond_client_base
+
+patches:
+  - path: ip-prefix-patch.yaml
+EOF
+
+cat > "$metalbond_client_overlay/ip-prefix-patch.yaml" <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: metalbond-client
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - name: metalbond-arp
+          command:
+            - spoofer
+            - --interface
+            - eth0
+            - --ip-prefix
+            - $public_cidr_ipv4
+EOF

--- a/hack/render-public-vip-overlays.sh
+++ b/hack/render-public-vip-overlays.sh
@@ -49,6 +49,11 @@ sed -E "s#--public-prefix=[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+#--public-pref
     "$repo_root/base/ironcore-net/patch-apiserver-deployment.yaml" \
     > "$ironcore_net_overlay/public-prefix-patch.yaml"
 
+if ! grep -Fq -- "--public-prefix=$public_prefix_ipv4" "$ironcore_net_overlay/public-prefix-patch.yaml"; then
+    echo "failed to patch public prefix in ironcore-net overlay" >&2
+    exit 1
+fi
+
 cat > "$metalbond_client_overlay/kustomization.yaml" <<EOF
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/hack/render-public-vip-overlays.sh
+++ b/hack/render-public-vip-overlays.sh
@@ -5,6 +5,30 @@
 
 set -euo pipefail
 
+# Portable replacement for GNU realpath --relative-to (BSD realpath lacks this flag).
+# Usage: _relpath <target> <base>
+_relpath() {
+    local target base
+    target=$(cd "$1" && pwd)
+    base=$(cd "$2" && pwd)
+
+    local common="$base"
+    while [ "${target#"$common"}" = "$target" ]; do
+        common=$(dirname "$common")
+    done
+
+    local up=""
+    local rest="$base"
+    while [ "$rest" != "$common" ]; do
+        up="../$up"
+        rest=$(dirname "$rest")
+    done
+
+    local rel="${target#"$common"}"
+    rel="${rel#/}"
+    printf '%s\n' "${up}${rel}"
+}
+
 if [ "$#" -ne 3 ]; then
     echo "usage: $0 <container-runtime-binary> <kind-cluster-name> <runtime-overlays-dir>" >&2
     exit 1
@@ -31,8 +55,8 @@ ironcore_net_overlay="$runtime_overlays_dir/ironcore-net"
 metalbond_client_overlay="$runtime_overlays_dir/metalbond-client"
 mkdir -p "$ironcore_net_overlay" "$metalbond_client_overlay"
 
-ironcore_net_base=$(realpath --relative-to "$ironcore_net_overlay" "$repo_root/cluster/local/ironcore-net")
-metalbond_client_base=$(realpath --relative-to "$metalbond_client_overlay" "$repo_root/cluster/local/metalbond-client")
+ironcore_net_base=$(_relpath "$repo_root/cluster/local/ironcore-net" "$ironcore_net_overlay")
+metalbond_client_base=$(_relpath "$repo_root/cluster/local/metalbond-client" "$metalbond_client_overlay")
 
 cat > "$ironcore_net_overlay/kustomization.yaml" <<EOF
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/hack/render-public-vip-overlays.sh
+++ b/hack/render-public-vip-overlays.sh
@@ -38,6 +38,11 @@ runtime_bin=$1; shift
 kind_cluster_name=$1; shift
 runtime_overlays_dir=$1; shift
 
+if [ "$(basename "$runtime_bin")" = "podman" ]; then
+    echo "Skipping public VIP overlay rendering: not supported with podman (using static base configs)."
+    exit 0
+fi
+
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 public_vip_config=$("$repo_root/hack/detect-public-vip-config.sh" "$runtime_bin" "$kind_cluster_name")
 public_prefix_ipv4=$(awk -F= '$1 == "PUBLIC_PREFIX_IPV4" {print $2}' <<<"$public_vip_config")

--- a/hack/validate-kustomize.sh
+++ b/hack/validate-kustomize.sh
@@ -3,6 +3,7 @@
 set -e
 
 BASEDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPOROOT="$BASEDIR/.."
 export TERM="xterm-256color"
 
 bold="$(tput bold)"
@@ -12,7 +13,7 @@ normal="$(tput sgr0)"
 
 for kustomization in "$BASEDIR"/../base/**/kustomization.yaml; do
   path="$(dirname "$kustomization")"
-  dir="$(realpath --relative-to "$BASEDIR"/.. "$path")"
+  dir="${path#"$REPOROOT"/}"
   echo "${bold}Validating $dir${normal}"
   if ! kustomize_output="$(kustomize build "$path" 2>&1)"; then
     echo "${red}Kustomize build $dir failed:"
@@ -24,7 +25,7 @@ done
 
 for kustomization in "$BASEDIR"/../cluster/local/**/kustomization.yaml; do
   path="$(dirname "$kustomization")"
-  dir="$(realpath --relative-to "$BASEDIR"/.. "$path")"
+  dir="${path#"$REPOROOT"/}"
   echo "${bold}Validating $dir${normal}"
   if ! kustomize_output="$(kustomize build "$path" 2>&1)"; then
     echo "${red}Kustomize build $dir failed:"

--- a/tests/test_deploy.bats
+++ b/tests/test_deploy.bats
@@ -21,16 +21,16 @@ teardown() {
     if [ "$BATS_TEST_DESCRIPTION" == "Deploy VM" ]; then
         log info "Tearing down $BATS_TEST_DESCRIPTION"
         $KUBECTL_CTX delete -f "$EXAMPLES/network/examples/network.yaml"
-        apply_networkinterface_example delete
+        networkinterface_example delete
         $KUBECTL_CTX delete -f "$EXAMPLES/machine/machine.yaml"
     fi
 
 }
 
-apply_networkinterface_example() {
+networkinterface_example() {
     local action=$1; shift
     if [ "$action" != "apply" ] && [ "$action" != "delete" ]; then
-        log err "Invalid action for apply_networkinterface_example: '$action'. Expected apply|delete."
+        log err "Invalid action for networkinterface_example: '$action'. Expected apply|delete."
         return 1
     fi
     local runtime="docker"
@@ -42,7 +42,7 @@ apply_networkinterface_example() {
 
 @test "Deploy VM" {
     $KUBECTL_CTX apply -f "$EXAMPLES/network/examples/network.yaml"
-    apply_networkinterface_example apply
+    networkinterface_example apply
     $KUBECTL_CTX apply -f "$EXAMPLES/machine/machine.yaml"
 
     wait_for 600 machines_ready

--- a/tests/test_deploy.bats
+++ b/tests/test_deploy.bats
@@ -21,15 +21,28 @@ teardown() {
     if [ "$BATS_TEST_DESCRIPTION" == "Deploy VM" ]; then
         log info "Tearing down $BATS_TEST_DESCRIPTION"
         $KUBECTL_CTX delete -f "$EXAMPLES/network/examples/network.yaml"
-        $KUBECTL_CTX delete -f "$EXAMPLES/network/examples/networkinterface.yaml"
+        apply_networkinterface_example delete
         $KUBECTL_CTX delete -f "$EXAMPLES/machine/machine.yaml"
     fi
 
 }
 
+apply_networkinterface_example() {
+    local action=$1; shift
+    if [ "$action" != "apply" ] && [ "$action" != "delete" ]; then
+        log err "Invalid action for apply_networkinterface_example: '$action'. Expected apply|delete."
+        return 1
+    fi
+    local runtime="docker"
+    command -v docker &>/dev/null || runtime="podman"
+    local vip
+    vip=$(hack/detect-public-vip-config.sh "$runtime" "$KIND_CLUSTER_NAME" | awk -F= '$1 == "PUBLIC_VIP_IPV4" {print $2}')
+    sed -E "s#^([[:space:]]*virtualIP:).*#\\1 $vip#g" "$EXAMPLES/network/examples/networkinterface.yaml" | $KUBECTL_CTX "$action" -f -
+}
+
 @test "Deploy VM" {
     $KUBECTL_CTX apply -f "$EXAMPLES/network/examples/network.yaml"
-    $KUBECTL_CTX apply -f "$EXAMPLES/network/examples/networkinterface.yaml"
+    apply_networkinterface_example apply
     $KUBECTL_CTX apply -f "$EXAMPLES/machine/machine.yaml"
 
     wait_for 600 machines_ready

--- a/tests/test_deploy.bats
+++ b/tests/test_deploy.bats
@@ -49,5 +49,5 @@ networkinterface_example() {
 
     local machine_ip
     machine_ip=$(get_virtual_ip webapp)
-    wait_for 60 check_example_machine_ssh "$machine_ip"
+    wait_for 180 check_example_machine_ssh "$machine_ip"
 }

--- a/tests/test_detect_public_vip_config.bats
+++ b/tests/test_detect_public_vip_config.bats
@@ -13,9 +13,25 @@ teardown() {
     rm -rf "$TMPDIR"
 }
 
+# create_cre_mock SUBNET [EMIT_NETWORK] [INSPECT_NETWORKS] [BRIDGE_SUBNET]
+#
+# Generate a mock container-runtime executable at $CRE_MOCK that implements the
+# two commands used by hack/detect-public-vip-config.sh:
+#   * inspect <cluster>-control-plane
+#   * network inspect kind
+#
+# Example:
+#   create_cre_mock "172.19.0.0/16"
+#   run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
+#   assert_line "PUBLIC_CIDR_IPV4=172.19.1.0/24"
+#
+# If EMIT_NETWORK is "no", the mock simulates missing network discovery.
+# INSPECT_NETWORKS may contain multiple network names separated by newlines.
 create_cre_mock() {
     local subnet=$1; shift
     local emit_network=${1:-yes}; shift || true
+    local inspect_networks=${1:-kind}; shift || true
+    local bridge_subnet=${1:-}; shift || true
 
     cat > "$CRE_MOCK" <<EOF
 #!/usr/bin/env bash
@@ -24,19 +40,34 @@ set -euo pipefail
 if [ "\$1" = "inspect" ] && [ "\$2" = "ironcore-in-a-box-control-plane" ]; then
 EOF
     if [ "$emit_network" = "yes" ]; then
-        cat >> "$CRE_MOCK" <<'EOF'
-    echo "kind"
+        cat >> "$CRE_MOCK" <<EOF
+    cat <<'NETWORKS'
+$inspect_networks
+NETWORKS
 EOF
     fi
     cat >> "$CRE_MOCK" <<'EOF'
     exit 0
 fi
 
-if [ "$1" = "network" ] && [ "$2" = "inspect" ] && [ "$3" = "kind" ]; then
+if [ "$1" = "network" ] && [ "$2" = "inspect" ]; then
+    if [ "$3" = "kind" ]; then
 EOF
     if [ -n "$subnet" ]; then
         cat >> "$CRE_MOCK" <<EOF
-    echo "$subnet"
+        echo "$subnet"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'EOF'
+        exit 0
+    fi
+EOF
+    if [ -n "$bridge_subnet" ]; then
+        cat >> "$CRE_MOCK" <<EOF
+    if [ "\$3" = "bridge" ]; then
+        echo "$bridge_subnet"
+        exit 0
+    fi
 EOF
     fi
     cat >> "$CRE_MOCK" <<'EOF'
@@ -57,6 +88,7 @@ EOF
         "172.20.0.0/16 172.20.1.1/24 172.20.1.0/24 172.20.1.1"
         "172.21.0.0/16 172.21.1.1/24 172.21.1.0/24 172.21.1.1"
     )
+    local c
 
     for c in "${cases[@]}"; do
         read -r subnet prefix cidr vip <<<"$c"
@@ -89,4 +121,15 @@ EOF
 
     assert_failure
     assert_line --partial "failed to detect container network"
+}
+
+@test "prefers kind network when multiple networks are attached" {
+    create_cre_mock "172.30.0.0/16" "yes" $'bridge\nkind' "10.88.7.0/24"
+
+    run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
+
+    assert_success
+    assert_line "PUBLIC_PREFIX_IPV4=172.30.1.1/24"
+    assert_line "PUBLIC_CIDR_IPV4=172.30.1.0/24"
+    assert_line "PUBLIC_VIP_IPV4=172.30.1.1"
 }

--- a/tests/test_detect_public_vip_config.bats
+++ b/tests/test_detect_public_vip_config.bats
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+setup() {
+    load "$BATS_SOURCES/bats-support/load.bash"
+    load "$BATS_SOURCES/bats-assert/load.bash"
+
+    TMPDIR=$(mktemp -d)
+    CRE_MOCK="$TMPDIR/cre-mock.sh"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+create_cre_mock() {
+    local subnet=$1; shift
+    local emit_network=${1:-yes}; shift || true
+
+    cat > "$CRE_MOCK" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\$1" = "inspect" ] && [ "\$2" = "ironcore-in-a-box-control-plane" ]; then
+EOF
+    if [ "$emit_network" = "yes" ]; then
+        cat >> "$CRE_MOCK" <<'EOF'
+    echo "kind"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'EOF'
+    exit 0
+fi
+
+if [ "$1" = "network" ] && [ "$2" = "inspect" ] && [ "$3" = "kind" ]; then
+EOF
+    if [ -n "$subnet" ]; then
+        cat >> "$CRE_MOCK" <<EOF
+    echo "$subnet"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'EOF'
+    exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 1
+EOF
+
+    chmod +x "$CRE_MOCK"
+}
+
+@test "detects VIP config for common kind /16 ranges" {
+    local cases=(
+        "172.18.0.0/16 172.18.1.1/24 172.18.1.0/24 172.18.1.1"
+        "172.19.0.0/16 172.19.1.1/24 172.19.1.0/24 172.19.1.1"
+        "172.20.0.0/16 172.20.1.1/24 172.20.1.0/24 172.20.1.1"
+        "172.21.0.0/16 172.21.1.1/24 172.21.1.0/24 172.21.1.1"
+    )
+
+    for c in "${cases[@]}"; do
+        read -r subnet prefix cidr vip <<<"$c"
+        create_cre_mock "$subnet"
+
+        run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
+
+        assert_success
+        assert_line "PUBLIC_PREFIX_IPV4=$prefix"
+        assert_line "PUBLIC_CIDR_IPV4=$cidr"
+        assert_line "PUBLIC_VIP_IPV4=$vip"
+    done
+}
+
+@test "detects VIP config for /24 ranges" {
+    create_cre_mock "10.88.7.0/24"
+
+    run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
+
+    assert_success
+    assert_line "PUBLIC_PREFIX_IPV4=10.88.7.1/24"
+    assert_line "PUBLIC_CIDR_IPV4=10.88.7.0/24"
+    assert_line "PUBLIC_VIP_IPV4=10.88.7.1"
+}
+
+@test "fails when network cannot be detected" {
+    create_cre_mock "" "no"
+
+    run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
+
+    assert_failure
+    assert_line --partial "failed to detect container network"
+}

--- a/tests/test_detect_public_vip_config.bats
+++ b/tests/test_detect_public_vip_config.bats
@@ -4,6 +4,7 @@
 setup() {
     load "$BATS_SOURCES/bats-support/load.bash"
     load "$BATS_SOURCES/bats-assert/load.bash"
+    load "test_helpers/common.sh"
 
     TMPDIR=$(mktemp -d)
     CRE_MOCK="$TMPDIR/cre-mock.sh"
@@ -11,74 +12,6 @@ setup() {
 
 teardown() {
     rm -rf "$TMPDIR"
-}
-
-# create_cre_mock SUBNET [EMIT_NETWORK] [INSPECT_NETWORKS] [BRIDGE_SUBNET]
-#
-# Generate a mock container-runtime executable at $CRE_MOCK that implements the
-# two commands used by hack/detect-public-vip-config.sh:
-#   * inspect <cluster>-control-plane
-#   * network inspect kind
-#
-# Example:
-#   create_cre_mock "172.19.0.0/16"
-#   run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
-#   assert_line "PUBLIC_CIDR_IPV4=172.19.1.0/24"
-#
-# If EMIT_NETWORK is "no", the mock simulates missing network discovery.
-# INSPECT_NETWORKS may contain multiple network names separated by newlines.
-create_cre_mock() {
-    local subnet=$1; shift
-    local emit_network=${1:-yes}; shift || true
-    local inspect_networks=${1:-kind}; shift || true
-    local bridge_subnet=${1:-}; shift || true
-
-    cat > "$CRE_MOCK" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [ "\$1" = "inspect" ] && [ "\$2" = "ironcore-in-a-box-control-plane" ]; then
-EOF
-    if [ "$emit_network" = "yes" ]; then
-        cat >> "$CRE_MOCK" <<EOF
-    cat <<'NETWORKS'
-$inspect_networks
-NETWORKS
-EOF
-    fi
-    cat >> "$CRE_MOCK" <<'EOF'
-    exit 0
-fi
-
-if [ "$1" = "network" ] && [ "$2" = "inspect" ]; then
-    if [ "$3" = "kind" ]; then
-EOF
-    if [ -n "$subnet" ]; then
-        cat >> "$CRE_MOCK" <<EOF
-        echo "$subnet"
-EOF
-    fi
-    cat >> "$CRE_MOCK" <<'EOF'
-        exit 0
-    fi
-EOF
-    if [ -n "$bridge_subnet" ]; then
-        cat >> "$CRE_MOCK" <<EOF
-    if [ "\$3" = "bridge" ]; then
-        echo "$bridge_subnet"
-        exit 0
-    fi
-EOF
-    fi
-    cat >> "$CRE_MOCK" <<'EOF'
-    exit 0
-fi
-
-echo "unexpected args: $*" >&2
-exit 1
-EOF
-
-    chmod +x "$CRE_MOCK"
 }
 
 @test "detects VIP config for common kind /16 ranges" {
@@ -114,22 +47,11 @@ EOF
     assert_line "PUBLIC_VIP_IPV4=10.88.7.1"
 }
 
-@test "fails when network cannot be detected" {
-    create_cre_mock "" "no"
+@test "fails when kind network has no IPv4 subnet" {
+    create_cre_mock ""
 
     run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
 
     assert_failure
-    assert_line --partial "failed to detect container network"
-}
-
-@test "prefers kind network when multiple networks are attached" {
-    create_cre_mock "172.30.0.0/16" "yes" $'bridge\nkind' "10.88.7.0/24"
-
-    run hack/detect-public-vip-config.sh "$CRE_MOCK" "ironcore-in-a-box"
-
-    assert_success
-    assert_line "PUBLIC_PREFIX_IPV4=172.30.1.1/24"
-    assert_line "PUBLIC_CIDR_IPV4=172.30.1.0/24"
-    assert_line "PUBLIC_VIP_IPV4=172.30.1.1"
+    assert_line --partial "failed to detect IPv4 subnet"
 }

--- a/tests/test_helpers/common.sh
+++ b/tests/test_helpers/common.sh
@@ -128,3 +128,43 @@ succeed_for() {
     log err "Command wasn't stable for required amount of attempts ($duration): '$*'"
     return 1
 }
+
+# create_cre_mock SUBNET
+#
+# Generate a mock container-runtime executable at $CRE_MOCK that implements the
+# "network inspect kind" command used by hack/detect-public-vip-config.sh.
+#
+# The caller must set the CRE_MOCK variable to the desired output path before
+# invoking this function.
+#
+# Example:
+#   CRE_MOCK="$TMPDIR/cre-mock.sh"
+#   create_cre_mock "172.19.0.0/16"
+#   run hack/detect-public-vip-config.sh "$CRE_MOCK"
+#   assert_line "PUBLIC_CIDR_IPV4=172.19.1.0/24"
+#
+# Pass an empty SUBNET to simulate a failure (no IPv4 subnet found).
+create_cre_mock() {
+    local subnet=$1; shift
+
+    cat > "$CRE_MOCK" <<'HEADER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "network" ] && [ "$2" = "inspect" ] && [ "$3" = "kind" ]; then
+HEADER
+    if [ -n "$subnet" ]; then
+        cat >> "$CRE_MOCK" <<EOF
+    echo "$subnet"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'FOOTER'
+    exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 1
+FOOTER
+
+    chmod +x "$CRE_MOCK"
+}

--- a/tests/test_render_public_vip_overlays.bats
+++ b/tests/test_render_public_vip_overlays.bats
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+setup() {
+    load "$BATS_SOURCES/bats-support/load.bash"
+    load "$BATS_SOURCES/bats-assert/load.bash"
+
+    TMPDIR=$(mktemp -d)
+    CRE_MOCK="$TMPDIR/cre-mock.sh"
+    RUNTIME_OVERLAYS_DIR="$TMPDIR/runtime-overlays"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+create_cre_mock() {
+    local subnet=$1; shift
+    local emit_network=${1:-yes}; shift || true
+
+    cat > "$CRE_MOCK" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\$1" = "inspect" ] && [ "\$2" = "ironcore-in-a-box-control-plane" ]; then
+EOF
+    if [ "$emit_network" = "yes" ]; then
+        cat >> "$CRE_MOCK" <<'EOF'
+    echo "kind"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'EOF'
+    exit 0
+fi
+
+if [ "$1" = "network" ] && [ "$2" = "inspect" ] && [ "$3" = "kind" ]; then
+EOF
+    if [ -n "$subnet" ]; then
+        cat >> "$CRE_MOCK" <<EOF
+    echo "$subnet"
+EOF
+    fi
+    cat >> "$CRE_MOCK" <<'EOF'
+    exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 1
+EOF
+
+    chmod +x "$CRE_MOCK"
+}
+
+@test "renders runtime overlays using detected public VIP config" {
+    create_cre_mock "172.22.0.0/16"
+
+    run hack/render-public-vip-overlays.sh "$CRE_MOCK" "ironcore-in-a-box" "$RUNTIME_OVERLAYS_DIR"
+
+    assert_success
+    assert_line --partial "Detected public VIP configuration:"
+    assert_line --partial "PUBLIC_PREFIX_IPV4=172.22.1.1/24"
+    assert_line --partial "PUBLIC_CIDR_IPV4=172.22.1.0/24"
+
+    local ironcore_kustomization="$RUNTIME_OVERLAYS_DIR/ironcore-net/kustomization.yaml"
+    local metalbond_kustomization="$RUNTIME_OVERLAYS_DIR/metalbond-client/kustomization.yaml"
+    local public_prefix_patch="$RUNTIME_OVERLAYS_DIR/ironcore-net/public-prefix-patch.yaml"
+    local ip_prefix_patch="$RUNTIME_OVERLAYS_DIR/metalbond-client/ip-prefix-patch.yaml"
+
+    [ -f "$ironcore_kustomization" ]
+    [ -f "$metalbond_kustomization" ]
+    [ -f "$public_prefix_patch" ]
+    [ -f "$ip_prefix_patch" ]
+
+    run grep -E "cluster/local/ironcore-net$" "$ironcore_kustomization"
+    assert_success
+
+    run grep -E "cluster/local/metalbond-client$" "$metalbond_kustomization"
+    assert_success
+
+    run grep -F -- "--public-prefix=172.22.1.1/24" "$public_prefix_patch"
+    assert_success
+
+    run grep -F -- "- 172.22.1.0/24" "$ip_prefix_patch"
+    assert_success
+}
+
+@test "fails when public VIP config cannot be detected" {
+    create_cre_mock "" "no"
+
+    run hack/render-public-vip-overlays.sh "$CRE_MOCK" "ironcore-in-a-box" "$RUNTIME_OVERLAYS_DIR"
+
+    assert_failure
+    assert_line --partial "failed to detect container network"
+}
+
+@test "fails when ironcore-net patch template has no public-prefix argument" {
+    create_cre_mock "172.22.0.0/16"
+
+    local sandbox_repo="$TMPDIR/repo"
+    local sandbox_overlays="$TMPDIR/sandbox-overlays"
+    mkdir -p \
+        "$sandbox_repo/hack" \
+        "$sandbox_repo/base/ironcore-net" \
+        "$sandbox_repo/cluster/local/ironcore-net" \
+        "$sandbox_repo/cluster/local/metalbond-client"
+
+    cp hack/detect-public-vip-config.sh "$sandbox_repo/hack/"
+    cp hack/render-public-vip-overlays.sh "$sandbox_repo/hack/"
+    chmod +x "$sandbox_repo/hack/detect-public-vip-config.sh" "$sandbox_repo/hack/render-public-vip-overlays.sh"
+
+    cat > "$sandbox_repo/base/ironcore-net/patch-apiserver-deployment.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apiserver
+spec:
+  template:
+    spec:
+      containers:
+        - name: kube-apiserver
+          command:
+            - kube-apiserver
+EOF
+
+    run "$sandbox_repo/hack/render-public-vip-overlays.sh" "$CRE_MOCK" "ironcore-in-a-box" "$sandbox_overlays"
+
+    assert_failure
+    assert_line --partial "failed to patch public prefix in ironcore-net overlay"
+}

--- a/tests/test_render_public_vip_overlays.bats
+++ b/tests/test_render_public_vip_overlays.bats
@@ -4,6 +4,7 @@
 setup() {
     load "$BATS_SOURCES/bats-support/load.bash"
     load "$BATS_SOURCES/bats-assert/load.bash"
+    load "test_helpers/common.sh"
 
     TMPDIR=$(mktemp -d)
     CRE_MOCK="$TMPDIR/cre-mock.sh"
@@ -12,43 +13,6 @@ setup() {
 
 teardown() {
     rm -rf "$TMPDIR"
-}
-
-create_cre_mock() {
-    local subnet=$1; shift
-    local emit_network=${1:-yes}; shift || true
-
-    cat > "$CRE_MOCK" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [ "\$1" = "inspect" ] && [ "\$2" = "ironcore-in-a-box-control-plane" ]; then
-EOF
-    if [ "$emit_network" = "yes" ]; then
-        cat >> "$CRE_MOCK" <<'EOF'
-    echo "kind"
-EOF
-    fi
-    cat >> "$CRE_MOCK" <<'EOF'
-    exit 0
-fi
-
-if [ "$1" = "network" ] && [ "$2" = "inspect" ] && [ "$3" = "kind" ]; then
-EOF
-    if [ -n "$subnet" ]; then
-        cat >> "$CRE_MOCK" <<EOF
-    echo "$subnet"
-EOF
-    fi
-    cat >> "$CRE_MOCK" <<'EOF'
-    exit 0
-fi
-
-echo "unexpected args: $*" >&2
-exit 1
-EOF
-
-    chmod +x "$CRE_MOCK"
 }
 
 @test "renders runtime overlays using detected public VIP config" {
@@ -85,12 +49,12 @@ EOF
 }
 
 @test "fails when public VIP config cannot be detected" {
-    create_cre_mock "" "no"
+    create_cre_mock ""
 
     run hack/render-public-vip-overlays.sh "$CRE_MOCK" "ironcore-in-a-box" "$RUNTIME_OVERLAYS_DIR"
 
     assert_failure
-    assert_line --partial "failed to detect container network"
+    assert_line --partial "failed to detect IPv4 subnet"
 }
 
 @test "fails when ironcore-net patch template has no public-prefix argument" {


### PR DESCRIPTION
# Proposed Changes

- Added `hack/detect-public-vip-config.sh` to detect the effective Kind IPv4 subnet from the container runtime network.
- Added `hack/render-public-vip-overlays.sh` to generate runtime kustomize overlays under `.tmp/runtime-overlays/` using the detected VIP CIDR/prefix.
- Updated `Makefile` to render/apply these runtime overlays before installing `ironcore-net` and `metalbond-client`.
- Removed fixed `172.18.1.x` assumptions from test flow by dynamically injecting the detected VIP into the example `NetworkInterface` manifest.
- Added/updated BATS coverage for VIP detection, including multiple `/16` ranges and failure behavior when network discovery is not possible.

# Fixes

On my machine, Docker already had `172.18.0.0/16` in use, so Kind was created on `172.19.0.0/16`.  
The previous hardcoded `172.18.1.x` assumptions caused routing/ARP mismatch and SSH failures (`No route to host`).

This PR makes VIP configuration subnet-aware by deriving it from the actual Kind network, so environments where Kind lands on `172.18.x`, `172.19.x`, `172.20.x`, `172.21.x`, etc., are handled correctly.
