### PR TITLE
Update libvirt-provider to v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,15 @@ RUN sed -i 's/UID_MAX.*/UID_MAX 65536/' /etc/login.defs && \
 
 # Install libvirt and qemu-kvm
 RUN apt-get update && \
-    apt-get install -y libvirt-daemon libvirt-clients qemu-kvm libvirt-daemon-system virtinst ceph-common && \
+    apt-get install -y libvirt-daemon libvirt-clients qemu-kvm libvirt-daemon-system virtinst ceph-common ovmf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Create libvirt-provider user/group and working directory
+RUN groupadd -g 65532 libvirt-provider && \
+    useradd -u 65532 -g libvirt-provider -M -s /usr/sbin/nologin libvirt-provider && \
+    usermod -aG libvirt libvirt-provider && \
+    usermod -aG libvirt-provider libvirt-qemu && \
+    mkdir -p /var/lib/libvirt-provider && \
+    chown libvirt-provider:libvirt-provider /var/lib/libvirt-provider && \
+    chmod 755 /var/lib/libvirt-provider

--- a/base/libvirt-provider/kustomization.yaml
+++ b/base/libvirt-provider/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/ironcore-dev/libvirt-provider/config/default?ref=3105f1f2665e29be30a4037313547bad2b258511
+  - github.com/ironcore-dev/libvirt-provider/config/default?ref=v0.3.0
   - role-binding.yaml
   - role.yaml
 
@@ -12,7 +12,7 @@ images:
     newTag: sha-8e5ead5
   - name: libvirt-provider
     newName: ghcr.io/ironcore-dev/libvirt-provider
-    newTag: sha-3105f1f
+    newTag: v0.3.0
 
 patches:
   - path: patch-manager-daemonset.yaml

--- a/base/libvirt-provider/kustomization.yaml
+++ b/base/libvirt-provider/kustomization.yaml
@@ -12,7 +12,7 @@ images:
     newTag: sha-8e5ead5
   - name: libvirt-provider
     newName: ghcr.io/ironcore-dev/libvirt-provider
-    newTag: v0.3.0
+    newTag: pr-717
 
 patches:
   - path: patch-manager-daemonset.yaml

--- a/cluster/local/libvirt-provider/patch-manager-args.yaml
+++ b/cluster/local/libvirt-provider/patch-manager-args.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   template:
     spec:
-      initContainers: []
       containers:
         - name: manager
           args:
@@ -21,7 +20,7 @@ spec:
         - name: provider
           args:
             - --address=/var/run/libvirt-provider.sock
-            - --supported-machine-classes=/var/cfg/classes/supported-machine-classes.json
+            - --supported-machine-classes=/var/cfg/classes/supported-machine-classes.yaml
             - --libvirt-socket=/var/run/libvirt/libvirt-sock
             - --libvirt-uri=qemu:///system
             - --libvirt-provider-dir=/var/lib/libvirt-provider
@@ -34,4 +33,3 @@ spec:
             - --preferred-machine-types=virt,pc-q35
             - --volume-cache-policy=writeback
             - --zap-log-level=3
-

--- a/cluster/local/libvirt-provider/supported-machine-classes-configmap.yaml
+++ b/cluster/local/libvirt-provider/supported-machine-classes-configmap.yaml
@@ -4,15 +4,11 @@ metadata:
   name: supported-machine-classes
   namespace: libvirt-provider-system
 data:
-  supported-machine-classes.json: |-
-    [
-      {
-        "name": "t3-small",
-        "capabilities": {
-          "resources": {
-            "cpu": 2,
-            "memory": 2147483648
-          }
-        }
-      }
-    ]
+  supported-machine-classes.yaml: |-
+    - apiVersion: compute.ironcore.dev/v1alpha1
+      kind: MachineClass
+      metadata:
+        name: t3-small
+      capabilities:
+        cpu: "2"
+        memory: 2Gi

--- a/tests/test_helpers/ironcore.sh
+++ b/tests/test_helpers/ironcore.sh
@@ -36,9 +36,9 @@ deploy_ironcore() {
         log info "Running 'make up' to spin up ironcore-in-a-box cluster. This may take a while..."
         make up KIND_IMAGE=ironcore-dev/kind-node:local
     fi
-    if ! wait_for 600 pods_ready; then
+    if ! wait_for 100 pods_ready; then
         log err "Pods did not become ready in time. Dumping libvirt-provider controller-manager logs:"
-        $KUBECTL_CTX logs -n libvirt-provider -l control-plane=controller-manager --all-containers=true 2>&1 || true
+        log info "$($KUBECTL_CTX logs -n libvirt-provider -l control-plane=controller-manager --all-containers=true 2>&1)" || true
         return 1
     fi
     succeed_for 10 60 pods_ready

--- a/tests/test_helpers/ironcore.sh
+++ b/tests/test_helpers/ironcore.sh
@@ -31,8 +31,10 @@ deploy_ironcore() {
     if [ "$output" == "$KIND_CLUSTER_NAME" ]; then
         log warn "Re-using existing $KIND_CLUSTER_NAME cluster"
     else
+        log info "Building custom kind node image..."
+        docker build -t ironcore-dev/kind-node:local .
         log info "Running 'make up' to spin up ironcore-in-a-box cluster. This may take a while..."
-        make up
+        make up KIND_IMAGE=ironcore-dev/kind-node:local
     fi
     wait_for 600 pods_ready
     succeed_for 10 60 pods_ready

--- a/tests/test_helpers/ironcore.sh
+++ b/tests/test_helpers/ironcore.sh
@@ -36,6 +36,10 @@ deploy_ironcore() {
         log info "Running 'make up' to spin up ironcore-in-a-box cluster. This may take a while..."
         make up KIND_IMAGE=ironcore-dev/kind-node:local
     fi
-    wait_for 600 pods_ready
+    if ! wait_for 600 pods_ready; then
+        log err "Pods did not become ready in time. Dumping libvirt-provider controller-manager logs:"
+        $KUBECTL_CTX logs -n libvirt-provider -l control-plane=controller-manager --all-containers=true 2>&1 || true
+        return 1
+    fi
     succeed_for 10 60 pods_ready
 }


### PR DESCRIPTION
- Migrate supported-machine-classes config from JSON to YAML
- Add libvirt-provider user/group and OVMF package in Dockerfile, this allows the initContainer checks of libvirt-provider v0.3.0 config to pass
- Remove empty initContainers override in patch, it did not have an effect
