### PR TITLE
Enable custom libvirt-provider image and config path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ KIND_IMAGE := ghcr.io/ironcore-dev/kind-node:latest
 # Configure the kind cluster name
 KIND_CLUSTER_NAME ?= ironcore-in-a-box
 export KIND_CLUSTER_NAME
+export LIBVIRT_PROVIDER_CONFIG_DIR
+export LIBVIRT_PROVIDER_IMAGE_TAG
 
 # Expected kubectl context for the kind cluster
 KIND_CONTEXT := kind-$(KIND_CLUSTER_NAME)
@@ -57,6 +59,16 @@ guard-cluster: ## Verify the target kind cluster exists and kubectl context is c
 render-public-vip-overlays: guard-cluster ## Render runtime kustomize overlays from detected public VIP config
 	@hack/render-public-vip-overlays.sh "$(CRE)" "$(KIND_CLUSTER_NAME)" "$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)"
 
+.PHONY: prepare-local-config
+prepare-local-config: ## Copy base/cluster to .tmp/config and apply local mutations
+	@hack/prepare-local-config.sh
+
+.PHONY: kind-load-libvirt-provider
+kind-load-libvirt-provider: guard-cluster ## Load local libvirt-provider image into kind cluster
+ifdef LIBVIRT_PROVIDER_IMAGE_TAG
+	$(KIND_CTX) load docker-image ghcr.io/ironcore-dev/libvirt-provider:$(LIBVIRT_PROVIDER_IMAGE_TAG)
+endif
+
 kind-cluster: kind ## Create a kind cluster
 	$(KIND_CTX) create cluster --image $(KIND_IMAGE) --config kind/kind-config.yaml
 
@@ -70,70 +82,70 @@ delete: ## Delete the kind cluster
 ## Install components
 up: prepare ironcore ironcore-net apinetlet setup-network metalnetlet libvirt-provider ## Bring up the ironcore stack
 
-prepare: kubectl cmctl kind-cluster ## Prepare the environment
-	$(KUBECTL_CTX) apply -k cluster/local/prepare
+prepare: prepare-local-config kubectl cmctl kind-cluster ## Prepare the environment
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/prepare
 	$(CMCTL) check api --wait 120s
 
 ironcore: prepare kubectl ## Install the ironcore
-	$(KUBECTL_CTX) apply -k cluster/local/ironcore
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/ironcore
 
 ironcore-net: render-public-vip-overlays guard-cluster kubectl ## Install the ironcore-net
 	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net",cluster/local/ironcore-net)
 
-apinetlet: guard-cluster kubectl ## Install the apinetlet
-	$(KUBECTL_CTX) apply -k cluster/local/apinetlet
+apinetlet: prepare-local-config guard-cluster kubectl ## Install the apinetlet
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/apinetlet
 
-metalnetlet: guard-cluster kubectl ## Install the metalnetlet
-	$(KUBECTL_CTX) apply -k cluster/local/metalnetlet
+metalnetlet: prepare-local-config guard-cluster kubectl ## Install the metalnetlet
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/metalnetlet
 
-metalbond: guard-cluster kubectl ## Install metalbond
-	$(KUBECTL_CTX) apply -k cluster/local/metalbond
+metalbond: prepare-local-config guard-cluster kubectl ## Install metalbond
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/metalbond
 
 metalbond-client: render-public-vip-overlays guard-cluster kubectl ## Install metalbond-client
 	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/metalbond-client",cluster/local/metalbond-client)
 
-dpservice: guard-cluster kubectl ## Install dpservice
-	$(KUBECTL_CTX) apply -k cluster/local/dpservice
+dpservice: prepare-local-config guard-cluster kubectl ## Install dpservice
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/dpservice
 
-metalnet: guard-cluster kubectl ## Install metalnet
-	$(KUBECTL_CTX) apply -k cluster/local/metalnet
+metalnet: prepare-local-config guard-cluster kubectl ## Install metalnet
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/metalnet
 
 
-libvirt-provider: guard-cluster kubectl ## Install the libvirt-provider
-	$(KUBECTL_CTX) apply -k cluster/local/libvirt-provider
+libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster kubectl ## Install the libvirt-provider
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/libvirt-provider
 
 ## Remove components
 down: remove-ironcore remove-ironcore-net remove-apinetlet remove-metalnet remove-dpservice remove-metalbond remove-metalbond-client remove-metalnetlet remove-libvirt-provider unprepare ## Remove the ironcore stack
 
 remove-ironcore: guard-cluster kubectl ## Remove the ironcore
-	$(KUBECTL_CTX) delete -k cluster/local/ironcore
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/ironcore
 
 remove-ironcore-net: guard-cluster kubectl ## Remove the ironcore
 	$(KUBECTL_CTX) delete -k cluster/local/ironcore-net
 
 remove-apinetlet: guard-cluster kubectl ## Remove the apinetlet
-	$(KUBECTL_CTX) delete -k cluster/local/apinetlet
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/apinetlet
 
 remove-metalnetlet: guard-cluster kubectl ## Remove the metalnetlet
-	$(KUBECTL_CTX) delete -k cluster/local/metalnetlet
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/metalnetlet
 
 remove-metalbond: guard-cluster kubectl ## Remove metalbond
-	$(KUBECTL_CTX) delete -k cluster/local/metalbond
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/metalbond
 
 remove-metalbond-client: guard-cluster kubectl ## Remove metalbond
 	$(KUBECTL_CTX) delete -k cluster/local/metalbond-client
 
 remove-dpservice: guard-cluster kubectl ## Remove dpservice
-	$(KUBECTL_CTX) delete -k cluster/local/dpservice
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/dpservice
 
 remove-metalnet: guard-cluster kubectl ## Remove metalnet
-	$(KUBECTL_CTX) delete -k cluster/local/metalnet
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/metalnet
 
 remove-libvirt-provider: guard-cluster kubectl ## Remove libvirt-provider
-	$(KUBECTL_CTX) delete -k cluster/local/libvirt-provider
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/libvirt-provider
 
 unprepare: guard-cluster kubectl ## Unprepare the environment
-	$(KUBECTL_CTX) delete -k cluster/local/prepare
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/prepare
 
 ##@ Dependencies
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ This command will:
 
 During `make up`, the IPv4 public VIP range is auto-detected from the current kind container network (for example `172.19.1.0/24` when kind runs on `172.19.0.0/16`) and used to render runtime kustomize overlays under `.tmp/runtime-overlays/`.
 
+### Running against a local libvirt-provider
+
+For development on `libvirt-provider` you can point IronCore in a Box at a local checkout and/or a custom image tag instead of the upstream defaults. When either of the following environment variables is set, `make up` writes a mutated copy of the kustomize tree to `.tmp/config/` and deploys from there:
+
+| Variable | Effect |
+|---|---|
+| `LIBVIRT_PROVIDER_CONFIG_DIR` | Replace the remote `github.com/ironcore-dev/libvirt-provider/config/default?ref=...` kustomize resource with a relative path to a local `libvirt-provider/config/default` directory. |
+| `LIBVIRT_PROVIDER_IMAGE_TAG` | Override the libvirt-provider container image tag (resolved against `ghcr.io/ironcore-dev/libvirt-provider`). |
+
+Example — deploy from a local checkout with a locally-built image:
+
+```sh
+LIBVIRT_PROVIDER_CONFIG_DIR=../libvirt-provider/config/default \
+LIBVIRT_PROVIDER_IMAGE_TAG=local \
+  make up
+```
+
+Both variables are independent and can be used on their own. With neither set, the upstream pinned versions are used unchanged.
+
 ## Examples
 
 You can find examples of how to use the IronCore API in the [Examples](examples/) directory. You can spin up a VM in a [VPC / Overlay Network](https://en.wikipedia.org/wiki/Virtual_private_cloud) with a virtual IP. Using the command `kubectl get machine,network,nic,virtualip` to find out status and more information regarding the provisioned VM. By default, VMs enable password login for easy accessing and testing. The default username and password are `ironcore` and `best123`. Customized ignition can be also generated and used for other purposes.

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Portable replacement for GNU realpath --relative-to (BSD realpath lacks this flag).
+# Both directories must exist.
+# Usage: relpath <target> <base>
+relpath() {
+    local target base
+    target=$(cd "$1" && pwd)
+    base=$(cd "$2" && pwd)
+
+    local common="$base"
+    while [ "${target#"$common"}" = "$target" ]; do
+        common=$(dirname "$common")
+    done
+
+    local up=""
+    local rest="$base"
+    while [ "$rest" != "$common" ]; do
+        up="../$up"
+        rest=$(dirname "$rest")
+    done
+
+    local rel="${target#"$common"}"
+    rel="${rel#/}"
+    printf '%s\n' "${up}${rel}"
+}

--- a/hack/mutate-libvirt-provider.sh
+++ b/hack/mutate-libvirt-provider.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <config-dir>" >&2
+    exit 1
+fi
+
+config_dir=$1
+kustomization_dir="$config_dir/base/libvirt-provider"
+
+config_ref="${LIBVIRT_PROVIDER_CONFIG_DIR:-}"
+image_tag="${LIBVIRT_PROVIDER_IMAGE_TAG:-}"
+
+if [ -z "$config_ref" ] && [ -z "$image_tag" ]; then
+    exit 0
+fi
+
+cd "$kustomization_dir"
+
+if [ -n "$config_ref" ]; then
+    rel_config=$(relpath "$config_ref" "$kustomization_dir")
+    remote_ref=$(grep -oE 'github\.com/ironcore-dev/libvirt-provider/config/default\?ref=[^ ]+' kustomization.yaml)
+    kustomize edit remove resource "$remote_ref"
+    kustomize edit add resource --no-verify "$rel_config"
+fi
+
+if [ -n "$image_tag" ]; then
+    kustomize edit set image "libvirt-provider=ghcr.io/ironcore-dev/libvirt-provider:$image_tag"
+fi

--- a/hack/mutate-libvirt-provider.sh
+++ b/hack/mutate-libvirt-provider.sh
@@ -3,6 +3,16 @@
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# Mutates <config-dir>/base/libvirt-provider/kustomization.yaml in-place so that
+# libvirt-provider is sourced from a local checkout and/or runs a custom image tag.
+# Both mutations are opt-in and gated by environment variables; with neither set,
+# the script is a no-op.
+#
+#   LIBVIRT_PROVIDER_CONFIG_DIR  Replace the remote `config/default?ref=...`
+#                                kustomize resource with a relative path to a
+#                                local libvirt-provider config directory.
+#   LIBVIRT_PROVIDER_IMAGE_TAG   Override the libvirt-provider image tag.
+
 set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
@@ -18,13 +28,8 @@ kustomization_dir="$config_dir/base/libvirt-provider"
 config_ref="${LIBVIRT_PROVIDER_CONFIG_DIR:-}"
 image_tag="${LIBVIRT_PROVIDER_IMAGE_TAG:-}"
 
-if [ -z "$config_ref" ] && [ -z "$image_tag" ]; then
-    exit 0
-fi
-
-cd "$kustomization_dir"
-
 if [ -n "$config_ref" ]; then
+    cd "$kustomization_dir"
     rel_config=$(relpath "$config_ref" "$kustomization_dir")
     remote_ref=$(grep -oE 'github\.com/ironcore-dev/libvirt-provider/config/default\?ref=[^ ]+' kustomization.yaml)
     kustomize edit remove resource "$remote_ref"
@@ -32,5 +37,6 @@ if [ -n "$config_ref" ]; then
 fi
 
 if [ -n "$image_tag" ]; then
+    cd "$kustomization_dir"
     kustomize edit set image "libvirt-provider=ghcr.io/ironcore-dev/libvirt-provider:$image_tag"
 fi

--- a/hack/prepare-local-config.sh
+++ b/hack/prepare-local-config.sh
@@ -3,15 +3,25 @@
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# Prepares a writable copy of base/ and cluster/ under .tmp/config/ and runs
+# all mutate-* scripts against it. Mutate scripts are no-ops unless their
+# corresponding override env vars are set (see hack/mutate-*.sh for details).
+
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 config_dir="$repo_root/.tmp/config"
 
-# Resolve relative env var paths to absolute while still in the caller's CWD
-if [ -n "${LIBVIRT_PROVIDER_CONFIG_DIR:-}" ] && [[ "${LIBVIRT_PROVIDER_CONFIG_DIR}" != /* ]]; then
-    export LIBVIRT_PROVIDER_CONFIG_DIR="$(cd "$LIBVIRT_PROVIDER_CONFIG_DIR" && pwd)"
-fi
+# Resolve relative env var paths to absolute while still in the caller's CWD,
+# so that subsequent `cd`s in mutate scripts don't break path references.
+case "${LIBVIRT_PROVIDER_CONFIG_DIR:-}" in
+    "" | /*)
+        # unset or already absolute — nothing to do
+        ;;
+    *)
+        export LIBVIRT_PROVIDER_CONFIG_DIR="$(cd "$LIBVIRT_PROVIDER_CONFIG_DIR" && pwd)"
+        ;;
+esac
 
 # Always start fresh
 rm -rf "$config_dir"

--- a/hack/prepare-local-config.sh
+++ b/hack/prepare-local-config.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+config_dir="$repo_root/.tmp/config"
+
+# Resolve relative env var paths to absolute while still in the caller's CWD
+if [ -n "${LIBVIRT_PROVIDER_CONFIG_DIR:-}" ] && [[ "${LIBVIRT_PROVIDER_CONFIG_DIR}" != /* ]]; then
+    export LIBVIRT_PROVIDER_CONFIG_DIR="$(cd "$LIBVIRT_PROVIDER_CONFIG_DIR" && pwd)"
+fi
+
+# Always start fresh
+rm -rf "$config_dir"
+mkdir -p "$config_dir"
+cp -r "$repo_root/base" "$config_dir/base"
+cp -r "$repo_root/cluster" "$config_dir/cluster"
+
+# Run all mutate scripts (each is a no-op if its env vars aren't set)
+"$repo_root/hack/mutate-libvirt-provider.sh" "$config_dir"

--- a/hack/render-public-vip-overlays.sh
+++ b/hack/render-public-vip-overlays.sh
@@ -5,29 +5,7 @@
 
 set -euo pipefail
 
-# Portable replacement for GNU realpath --relative-to (BSD realpath lacks this flag).
-# Usage: _relpath <target> <base>
-_relpath() {
-    local target base
-    target=$(cd "$1" && pwd)
-    base=$(cd "$2" && pwd)
-
-    local common="$base"
-    while [ "${target#"$common"}" = "$target" ]; do
-        common=$(dirname "$common")
-    done
-
-    local up=""
-    local rest="$base"
-    while [ "$rest" != "$common" ]; do
-        up="../$up"
-        rest=$(dirname "$rest")
-    done
-
-    local rel="${target#"$common"}"
-    rel="${rel#/}"
-    printf '%s\n' "${up}${rel}"
-}
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 if [ "$#" -ne 3 ]; then
     echo "usage: $0 <container-runtime-binary> <kind-cluster-name> <runtime-overlays-dir>" >&2
@@ -60,8 +38,8 @@ ironcore_net_overlay="$runtime_overlays_dir/ironcore-net"
 metalbond_client_overlay="$runtime_overlays_dir/metalbond-client"
 mkdir -p "$ironcore_net_overlay" "$metalbond_client_overlay"
 
-ironcore_net_base=$(_relpath "$repo_root/cluster/local/ironcore-net" "$ironcore_net_overlay")
-metalbond_client_base=$(_relpath "$repo_root/cluster/local/metalbond-client" "$metalbond_client_overlay")
+ironcore_net_base=$(relpath "$repo_root/cluster/local/ironcore-net" "$ironcore_net_overlay")
+metalbond_client_base=$(relpath "$repo_root/cluster/local/metalbond-client" "$metalbond_client_overlay")
 
 cat > "$ironcore_net_overlay/kustomization.yaml" <<EOF
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/test_prepare_local_config.bats
+++ b/tests/test_prepare_local_config.bats
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+    load "$BATS_SOURCES/bats-support/load.bash"
+    load "$BATS_SOURCES/bats-assert/load.bash"
+    load "test_helpers/common.sh"
+
+    ORIG_DIR=$(pwd)
+    SANDBOX=$(mktemp -d)
+    FAKE_PROVIDER_DIR="$SANDBOX/fake-provider-config"
+    mkdir -p "$FAKE_PROVIDER_DIR"
+    mkdir -p "$SANDBOX/base/libvirt-provider" "$SANDBOX/cluster/local/libvirt-provider" "$SANDBOX/hack"
+
+    # Copy real base and cluster content into sandbox
+    cp -r "$ORIG_DIR/base/"* "$SANDBOX/base/"
+    cp -r "$ORIG_DIR/cluster/"* "$SANDBOX/cluster/"
+    cp "$ORIG_DIR/hack/prepare-local-config.sh" "$SANDBOX/hack/"
+    cp "$ORIG_DIR/hack/mutate-libvirt-provider.sh" "$SANDBOX/hack/"
+    cp "$ORIG_DIR/hack/lib.sh" "$SANDBOX/hack/"
+    chmod +x "$SANDBOX/hack/prepare-local-config.sh" "$SANDBOX/hack/mutate-libvirt-provider.sh"
+
+    unset LIBVIRT_PROVIDER_CONFIG_DIR
+    unset LIBVIRT_PROVIDER_IMAGE_TAG
+
+    cd "$SANDBOX" || return
+}
+
+teardown() {
+    cd "$ORIG_DIR" || return
+    rm -rf "$SANDBOX"
+}
+
+@test "copies base and cluster to .tmp/config without mutations when no env vars set" {
+    run hack/prepare-local-config.sh
+
+    assert_success
+    assert [ -d ".tmp/config/base/libvirt-provider" ]
+    assert [ -d ".tmp/config/cluster/local/libvirt-provider" ]
+
+    # kustomization.yaml should be unchanged — still has remote git ref
+    run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+
+    run grep "newTag: v0.3.1" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+}
+
+@test "replaces remote resource with local path when LIBVIRT_PROVIDER_CONFIG_DIR is set" {
+    export LIBVIRT_PROVIDER_CONFIG_DIR="$FAKE_PROVIDER_DIR"
+
+    run hack/prepare-local-config.sh
+
+    assert_success
+
+    # Remote git ref should be gone
+    run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_failure
+
+    # Local path should be present (as relative path)
+    run grep -F "fake-provider" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+
+    # Image tag should be unchanged
+    run grep "newTag: v0.3.1" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+}
+
+@test "overrides image tag when LIBVIRT_PROVIDER_IMAGE_TAG is set" {
+    export LIBVIRT_PROVIDER_IMAGE_TAG="local"
+
+    run hack/prepare-local-config.sh
+
+    assert_success
+
+    # Remote git ref should still be present
+    run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+
+    # Image tag should be overridden
+    run grep "newTag: local" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+}
+
+@test "applies both mutations when both env vars are set" {
+    export LIBVIRT_PROVIDER_CONFIG_DIR="$FAKE_PROVIDER_DIR"
+    export LIBVIRT_PROVIDER_IMAGE_TAG="local"
+
+    run hack/prepare-local-config.sh
+
+    assert_success
+
+    # Remote git ref should be gone
+    run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_failure
+
+    # Local path should be present (as relative path)
+    run grep -F "fake-provider" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+
+    # Image tag should be overridden
+    run grep "newTag: local" .tmp/config/base/libvirt-provider/kustomization.yaml
+    assert_success
+}
+
+@test "idempotent: running twice produces same result" {
+    export LIBVIRT_PROVIDER_CONFIG_DIR="$FAKE_PROVIDER_DIR"
+    export LIBVIRT_PROVIDER_IMAGE_TAG="local"
+
+    hack/prepare-local-config.sh
+    local first_run
+    first_run=$(cat .tmp/config/base/libvirt-provider/kustomization.yaml)
+
+    hack/prepare-local-config.sh
+    local second_run
+    second_run=$(cat .tmp/config/base/libvirt-provider/kustomization.yaml)
+
+    [ "$first_run" = "$second_run" ]
+}

--- a/tests/test_prepare_local_config.bats
+++ b/tests/test_prepare_local_config.bats
@@ -34,9 +34,8 @@ teardown() {
 }
 
 @test "copies base and cluster to .tmp/config without mutations when no env vars set" {
-    run hack/prepare-local-config.sh
+    hack/prepare-local-config.sh
 
-    assert_success
     assert [ -d ".tmp/config/base/libvirt-provider" ]
     assert [ -d ".tmp/config/cluster/local/libvirt-provider" ]
 
@@ -51,9 +50,7 @@ teardown() {
 @test "replaces remote resource with local path when LIBVIRT_PROVIDER_CONFIG_DIR is set" {
     export LIBVIRT_PROVIDER_CONFIG_DIR="$FAKE_PROVIDER_DIR"
 
-    run hack/prepare-local-config.sh
-
-    assert_success
+    hack/prepare-local-config.sh
 
     # Remote git ref should be gone
     run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
@@ -71,9 +68,7 @@ teardown() {
 @test "overrides image tag when LIBVIRT_PROVIDER_IMAGE_TAG is set" {
     export LIBVIRT_PROVIDER_IMAGE_TAG="local"
 
-    run hack/prepare-local-config.sh
-
-    assert_success
+    hack/prepare-local-config.sh
 
     # Remote git ref should still be present
     run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml
@@ -88,9 +83,7 @@ teardown() {
     export LIBVIRT_PROVIDER_CONFIG_DIR="$FAKE_PROVIDER_DIR"
     export LIBVIRT_PROVIDER_IMAGE_TAG="local"
 
-    run hack/prepare-local-config.sh
-
-    assert_success
+    hack/prepare-local-config.sh
 
     # Remote git ref should be gone
     run grep -F "github.com/ironcore-dev/libvirt-provider/config/default" .tmp/config/base/libvirt-provider/kustomization.yaml

--- a/tests/test_render_public_vip_overlays.bats
+++ b/tests/test_render_public_vip_overlays.bats
@@ -70,6 +70,7 @@ teardown() {
 
     cp hack/detect-public-vip-config.sh "$sandbox_repo/hack/"
     cp hack/render-public-vip-overlays.sh "$sandbox_repo/hack/"
+    cp hack/lib.sh "$sandbox_repo/hack/"
     chmod +x "$sandbox_repo/hack/detect-public-vip-config.sh" "$sandbox_repo/hack/render-public-vip-overlays.sh"
 
     cat > "$sandbox_repo/base/ironcore-net/patch-apiserver-deployment.yaml" <<'EOF'


### PR DESCRIPTION
With these configuration options, libvirt-provider can run local changes against iiab easily.

This approach introduces a standard flow that copies all kustomization files and adjusts them via `kustomize edit` for dynamic overrides. Overlays are not applicapble for all scenarios, i.e. changing the path of resources.

This approach also removes complexity from the
invididual make targets, where overwrites need to be targeted with alternative paths.

Additional overwrites can be introduced using
the same mechanism.

ironcore-net and metalbond-client remain on the existing public VIP overlay mechanism for now, but will be migrated in a separate PR.

Alternatively a templating tool like `ytt` could solve this more elegantly at the cost of an additional tool.
