### PR TITLE
Remove ignore-paths from tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,6 @@ name: Tests
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   schedule:
     # Run regularly at 3:22 each Monday
     - cron: "22 3 * * 1"


### PR DESCRIPTION
# Proposed Changes

The tests workflow is mandatory. As docs and *.md changes are ignored, the
workflow will not run for such changes. This makes it impossible to
merge docs-only changes. Removing ignore-paths will fix this.
