### PR TITLE
Wait for ironcore aggregated APIs to become available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ prepare: prepare-local-config kubectl cmctl kind-cluster ## Prepare the environm
 
 ironcore: prepare kubectl ## Install the ironcore
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/ironcore
+	$(KUBECTL_CTX) -n ironcore-system rollout status deployment/ironcore-apiserver --timeout=5m
+	@echo "Waiting for ironcore aggregated APIs to become available..."
+	$(KUBECTL_CTX) get apiservice -o name | grep '\.ironcore\.dev$$' | xargs $(KUBECTL_CTX) wait --for=condition=Available --timeout=5m
 
 ironcore-net: render-public-vip-overlays guard-cluster kubectl ## Install the ironcore-net
 	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net",cluster/local/ironcore-net)


### PR DESCRIPTION
`make up` does not wait for all APIs to become available. This allows for a race where subsequent operations, e.g., from `make test`, run into problems, e.g., applying the `libvirt-provider` overlay. In the CI, the following error was observed:

    error: resource mapping not found for name: "t3-small" namespace:
    "libvirt-provider" from
    ".tmp/config/cluster/local/libvirt-provider": no matches for kind
    "MachineClass" in version "compute.ironcore.dev/v1alpha1"

This should be fixed by making the `ironcore` make target wait for the apiserver rollout and for all `*.ironcore.dev` API services to become available.
