### PR TITLE
Enable MachinePool Health Monitoring

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@v7
       - uses: imranismail/setup-kustomize@v3
         with:
-          kustomize-version: '5.0.0'
+          kustomize-version: '5.7.1'
       - run: |
           ./hack/validate-kustomize.sh

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ ifdef LIBVIRT_PROVIDER_IMAGE_TAG
 endif
 
 kind-cluster: kind ## Create a kind cluster
-	$(KIND_CTX) create cluster --image $(KIND_IMAGE) --config kind/kind-config.yaml
+	@if $(KIND) get clusters 2>/dev/null | grep -qx '$(KIND_CLUSTER_NAME)'; then \
+		echo "kind cluster '$(KIND_CLUSTER_NAME)' already exists, skipping creation."; \
+	else \
+		$(KIND_CTX) create cluster --image $(KIND_IMAGE) --config kind/kind-config.yaml; \
+	fi
 
 setup-network: guard-cluster metalbond metalbond-client dpservice metalnet ## Customize the network on the kind nodes
 	$(KUBECTL_CTX) rollout status daemonset/dpservice -n dpservice-system --timeout=360s && \
@@ -88,6 +92,13 @@ prepare: prepare-local-config kubectl cmctl kind-cluster ## Prepare the environm
 
 ironcore: prepare kubectl ## Install the ironcore
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/ironcore
+	@echo "Waiting for ironcore aggregated APIServices to become Available..."
+	$(KUBECTL_CTX) wait --for=condition=Available --timeout=300s \
+		apiservice/v1alpha1.core.ironcore.dev \
+		apiservice/v1alpha1.compute.ironcore.dev \
+		apiservice/v1alpha1.networking.ironcore.dev \
+		apiservice/v1alpha1.ipam.ironcore.dev \
+		apiservice/v1alpha1.storage.ironcore.dev
 
 ironcore-net: render-public-vip-overlays guard-cluster kubectl ## Install the ironcore-net
 	$(KUBECTL_CTX) apply -k $(if $(wildcard $(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net),"$(PUBLIC_VIP_RUNTIME_OVERLAYS_DIR)/ironcore-net",cluster/local/ironcore-net)
@@ -112,6 +123,7 @@ metalnet: prepare-local-config guard-cluster kubectl ## Install metalnet
 
 
 libvirt-provider: kind-load-libvirt-provider prepare-local-config guard-cluster kubectl ## Install the libvirt-provider
+	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/libvirt-provider-lease-rbac
 	$(KUBECTL_CTX) apply -k .tmp/config/cluster/local/libvirt-provider
 
 ## Remove components
@@ -143,6 +155,7 @@ remove-metalnet: guard-cluster kubectl ## Remove metalnet
 
 remove-libvirt-provider: guard-cluster kubectl ## Remove libvirt-provider
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/libvirt-provider --ignore-not-found=true
+	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/libvirt-provider-lease-rbac --ignore-not-found=true
 
 unprepare: guard-cluster kubectl ## Unprepare the environment
 	$(KUBECTL_CTX) delete -k .tmp/config/cluster/local/prepare --ignore-not-found=true

--- a/base/ironcore/kustomization.yaml
+++ b/base/ironcore/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/ironcore-dev/ironcore/config/etcdless?ref=v0.4.3
+  - github.com/ironcore-dev/ironcore/config/etcdless?ref=v0.5.0
   - certificates.yaml
 
 images:
   - name: apiserver
     newName: ghcr.io/ironcore-dev/ironcore-apiserver
-    newTag: v0.4.3
+    newTag: v0.5.0
   - name: controller
     newName: ghcr.io/ironcore-dev/ironcore-controller-manager
-    newTag: v0.4.3
+    newTag: v0.5.0
 
 patches:
   - path: patch-apiserver-deployment.yaml

--- a/base/libvirt-provider-lease-rbac/kustomization.yaml
+++ b/base/libvirt-provider-lease-rbac/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone kustomization for the lease RBAC the libvirt-provider's
+# machinepoollet needs in the `ironcore-machinepool-lease` namespace.
+#
+# This intentionally lives outside `base/libvirt-provider` because the parent
+# overlay `cluster/local/libvirt-provider` sets a top-level `namespace:` field,
+# which the kustomize namespace transformer would rewrite onto these
+# cross-namespace resources too.
+
+resources:
+  - lease-rbac.yaml

--- a/base/libvirt-provider-lease-rbac/lease-rbac.yaml
+++ b/base/libvirt-provider-lease-rbac/lease-rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: libvirt-provider-machinepool-lease
+  namespace: ironcore-machinepool-lease
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: libvirt-provider-machinepool-lease
+  namespace: ironcore-machinepool-lease
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: libvirt-provider-machinepool-lease
+subjects:
+  - kind: ServiceAccount
+    name: libvirt-provider-controller-manager
+    namespace: libvirt-provider

--- a/base/libvirt-provider/kustomization.yaml
+++ b/base/libvirt-provider/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
   - name: machinepoollet
     newName: ghcr.io/ironcore-dev/ironcore-machinepoollet
-    newTag: v0.4.3
+    newTag: v0.5.0
   - name: libvirt-provider
     newName: ghcr.io/ironcore-dev/libvirt-provider
     newTag: v0.4.0

--- a/cluster/local/libvirt-provider-lease-rbac/kustomization.yaml
+++ b/cluster/local/libvirt-provider-lease-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/libvirt-provider-lease-rbac


### PR DESCRIPTION
Consume the ironcore version with the feature and add the necessary configuration. The additional RBAC are necessary, because the `machinepoollet` in ironcore-in-a-box runs without bootstrap-kubeconfig and instead uses the libvirt-provider's service account.

Contributes to #https://github.com/ironcore-dev/ironcore/issues/1472
